### PR TITLE
Adds wallet RPC calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ This package provides some tooling for testing a bitcoin-core integration.  Feat
 Supported bitcoin-core versions
 ----
 
+Non-wallet RPC calls:
+
 * `v0.19.1`
 * `v0.20.0`
 * `v0.20.1`
 * `v0.21.0`
+* `v0.21.1`
 
+Wallet and PSBT RPC calls: 
+
+* `v0.21.0` - except where noted
+* `v0.21.1`
 
 Test suite
 ----

--- a/bitcoind-regtest/CHANGELOG.md
+++ b/bitcoind-regtest/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for bitcoind-regtest
 
+## 0.3.0.0 -- 2021-??-??
+
+* Expose bitcoind version in node handle
+* Enable wallets 
+
 ## 0.2.0.0 -- 2020-11-01 
 
 * Create zmq sockets for block and transaction subscriptions to the ephemeral node

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               bitcoind-regtest
-version:            0.2.0.0
+version:            0.3.0.0
 synopsis:           A library for working with bitcoin-core regtest networks
 homepage:           https://github.com/bitnomial/bitcoind-rpc
 license:            BSD-3-Clause
@@ -16,7 +16,7 @@ common core
     ghc-options:      -Wall -fno-warn-unused-do-bind
     build-depends:
           base                           >=4.12     && <4.15
-        , bitcoind-rpc                  ^>=0.2
+        , bitcoind-rpc                  ^>=0.3
         , cereal                        ^>=0.5
         , directory                     ^>=1.3
         , haskoin-core                   >=0.15     && <0.21

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -35,7 +35,8 @@ library
         Bitcoin.Core.Regtest
 
     build-depends:
-        containers                       >=0.5      && <0.7
+          attoparsec ^>=0.14
+        , containers >=0.5 && <0.7
 
 executable bitcoind-rpc-explorer
     import:         core

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -53,7 +53,16 @@ test-suite bitcoind-rpc-tests
     type:           exitcode-stdio-1.0
     main-is:        Main.hs
     hs-source-dirs: test/
+
+    other-modules:
+        Bitcoin.Core.Test.Misc
+        Bitcoin.Core.Test.PSBT
+        Bitcoin.Core.Test.Utils
+        Bitcoin.Core.Test.Wallet
+
     build-depends:
-          bitcoind-regtest
-        , tasty                          >=1.2 && <1.5
-        , tasty-hunit                   ^>=0.10
+          base64 ^>=0.4
+        , bitcoind-regtest
+        , containers ^>=0.6
+        , tasty >=1.2 && <1.5
+        , tasty-hunit ^>=0.10

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -18,7 +18,8 @@ common core
           base                           >=4.12     && <4.15
         , bitcoind-rpc                  ^>=0.2
         , cereal                        ^>=0.5
-        , haskoin-core                   >=0.15     && <0.19
+        , directory                     ^>=1.3
+        , haskoin-core                   >=0.15     && <0.21
         , http-client                    >=0.6      && <0.8
         , process                       ^>=1.6
         , servant                        >=0.15     && <0.19

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
@@ -71,6 +71,7 @@ import Haskoin.Transaction (
 import Haskoin.Util (encodeHex, maybeToEither)
 import Network.HTTP.Client (Manager)
 import Servant.API (BasicAuthData)
+import System.Directory (createDirectoryIfMissing)
 import System.IO (Handle, IOMode (..), openFile)
 import System.IO.Temp (getCanonicalTemporaryDirectory, withSystemTempDirectory)
 import System.Process (
@@ -117,6 +118,7 @@ withBitcoind ::
 withBitcoind port k = withSystemTempDirectory "bitcoind-rpc-tests" $ \dd -> do
     v <- bitcoindVersion
     tmp <- getCanonicalTemporaryDirectory
+    createDirectoryIfMissing True $ dd <> "/regtest/wallets"
     bracket (initBitcoind tmp dd port) stopBitcoind . const $ do
         auth <- basicAuthFromCookie $ dd <> "/regtest/.cookie"
         k $ NodeHandle port auth (rawTxSocket tmp) (rawBlockSocket tmp) v
@@ -159,7 +161,7 @@ bitcoind tmp ddir port output =
         [ "-regtest"
         , "-txindex"
         , "-blockfilterindex=1"
-        , "-disablewallet"
+        , "-walletdir=" <> ddir <> "/regtest/wallets"
         , "-datadir=" <> ddir
         , "-rpcport=" <> show port
         , "-zmqpubrawblock=" <> rawBlockSocket tmp

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Bitcoin.Core.Test.Misc (
+    miscRPC,
+) where
+
+import Control.Monad (replicateM)
+import Data.Text (Text)
+import Data.Word (Word64)
+import Haskoin.Address (Address (..), addrToText, pubKeyAddr)
+import Haskoin.Block (Block (..), BlockHash)
+import Haskoin.Constants (btcTest)
+import Haskoin.Crypto (SecKey)
+import Haskoin.Keys (
+    PubKeyI,
+    derivePubKeyI,
+    secKey,
+    wrapSecKey,
+ )
+import Haskoin.Transaction (OutPoint (..), Tx (..), TxHash, txHash)
+import Network.HTTP.Client (Manager)
+import Test.Tasty (TestTree, testGroup)
+
+import Bitcoin.Core.RPC
+import Bitcoin.Core.Regtest (NodeHandle)
+import qualified Bitcoin.Core.Regtest as R
+import Bitcoin.Core.Test.Utils (bitcoindTest, testRpc)
+
+miscRPC :: Manager -> NodeHandle -> TestTree
+miscRPC mgr h =
+    testGroup "other-rpcs" $
+        bitcoindTest mgr h
+            <$> [ testRpc "generatetoaddress" testGenerate
+                , testRpc "getbestblockhash" getBestBlockHash
+                , testRpc "getblockhash" $ getBlockHash 1
+                , testRpc "getblockfilter" testBlockFilter
+                , testRpc "getblockheader" testBlockHeader
+                , testRpc "getblock" testBlock
+                , testRpc "getblockcount" getBlockCount
+                , testRpc "getdifficulty" getDifficulty
+                , testRpc "getchaintips" getChainTips
+                , testRpc "getblockstats" testBlockStats
+                , testRpc "getchaintxstats" $ getChainTxStats Nothing Nothing
+                , testRpc "getmempoolinfo" getMempoolInfo
+                , testRpc "getrawmempool" getRawMempool
+                , testRpc "getrawtransaction" testGetTransaction
+                , testRpc "sendrawtransaction" testSendTransaction
+                , testRpc "createOutput" testCreateOutput
+                , testRpc "getmempoolancestors" testMempoolAncestors
+                , testRpc "getmempooldescendants" testMempoolDescendants
+                , testRpc "getpeerinfo" getPeerInfo
+                , testRpc "getconnectioncount" getConnectionCount
+                , testRpc "getnodeaddresses" $ getNodeAddresses (Just 10)
+                , testRpc "getaddednodeinfo" $ getAddedNodeInfo Nothing
+                , testRpc "listbanned" listBanned
+                , testRpc "getnettotals" getNetTotals
+                , testRpc "uptime" uptime
+                , testRpc "addnode" $ addNode "127.0.0.1:8448" Add
+                , testRpc "clearbanned" clearBanned
+                ]
+
+testGenerate :: BitcoindClient [BlockHash]
+testGenerate = generateToAddress 120 addrText Nothing
+
+key :: SecKey
+Just key = secKey "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+pk :: PubKeyI
+pk = derivePubKeyI $ wrapSecKey True key
+
+addr :: Address
+addr = pubKeyAddr pk
+
+addrText :: Text
+Just addrText = addrToText btcTest addr
+
+testBlock :: BitcoindClient Block
+testBlock = getBestBlockHash >>= getBlock
+
+testBlockFilter :: BitcoindClient CompactFilter
+testBlockFilter = getBestBlockHash >>= getBlockFilter
+
+testBlockHeader :: BitcoindClient BlockHeader
+testBlockHeader = getBestBlockHash >>= getBlockHeader
+
+testBlockStats :: BitcoindClient BlockStats
+testBlockStats = getBestBlockHash >>= getBlockStats
+
+testGetTransaction :: BitcoindClient Tx
+testGetTransaction =
+    getBestBlockHash >>= getBlock >>= (`getRawTransaction` Nothing) . txHash . head . blockTxns
+
+testSendTransaction :: BitcoindClient TxHash
+testSendTransaction = do
+    outp <- head <$> replicateM 101 R.generate
+    let Right (tx, _) = R.spendPackageOutputs [outp] (R.addrs !! 3) R.oneBitcoin
+    sendTransaction tx Nothing
+
+testMempoolAncestors :: BitcoindClient [TxHash]
+testMempoolAncestors = testSendTransaction >>= getMempoolAncestors
+
+testMempoolDescendants :: BitcoindClient [TxHash]
+testMempoolDescendants = testSendTransaction >>= getMempoolAncestors
+
+testCreateOutput :: BitcoindClient (OutPoint, Word64)
+testCreateOutput = R.createOutput (R.addrs !! 4) (2 * R.oneBitcoin)

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Bitcoin.Core.Test.PSBT (
+    psbtRPC,
+) where
+
+import Control.Monad (replicateM_, when)
+import Data.ByteString.Base64 (encodeBase64)
+import Data.Functor (void)
+import Data.Maybe (mapMaybe)
+import qualified Data.Serialize as S
+import Network.HTTP.Client (Manager)
+import Test.Tasty (TestTree, testGroup)
+
+import Bitcoin.Core.RPC (
+    BitcoindClient,
+    Descriptor (Descriptor),
+    ListUnspentOptions (ListUnspentOptions),
+    PsbtInput,
+    PsbtOutputs (PsbtOutputs),
+ )
+import qualified Bitcoin.Core.RPC as RPC
+import Bitcoin.Core.Regtest (NodeHandle, Version, nodeVersion, v21_0)
+import Bitcoin.Core.Test.Utils (
+    bitcoindTest,
+    generate,
+    initWallet,
+    testRpc,
+    toInput,
+    withWallet,
+ )
+
+psbtRPC :: Manager -> NodeHandle -> TestTree
+psbtRPC mgr h =
+    testGroup
+        "psbt-rpc"
+        [bitcoindTest mgr h $ testRpc "psbt" (testPSBT v)]
+  where
+    v = nodeVersion h
+
+data Fixture = Fixture
+    { inputsA :: [PsbtInput]
+    , descriptorsA :: [Descriptor]
+    , outputsA :: PsbtOutputs
+    , inputsB :: [PsbtInput]
+    , outputsB :: PsbtOutputs
+    }
+
+testPSBT :: Version -> BitcoindClient ()
+testPSBT v = when (v >= v21_0) $ do
+    initWallet wallet
+    fixture <- withWallet wallet $ do
+        replicateM_ 200 generate
+
+        utxos <-
+            filter ((> 6) . RPC.outputConfs)
+                <$> RPC.listUnspent
+                    Nothing
+                    Nothing
+                    Nothing
+                    (Just True)
+                    (ListUnspentOptions Nothing Nothing Nothing Nothing)
+
+        outputAddrA <- RPC.getNewAddress Nothing Nothing
+
+        let utxosA = take 3 utxos
+            utxosB = take 2 $ drop 3 utxos
+        pure
+            Fixture
+                { inputsA = toInput <$> utxosA
+                , outputsA = PsbtOutputs [(outputAddrA, 1_0000_0000)] Nothing
+                , descriptorsA = Descriptor <$> mapMaybe RPC.outputDescriptor utxosA
+                , inputsB = toInput <$> utxosB
+                , outputsB = PsbtOutputs mempty (Just "aabbcc")
+                }
+    psbtA <-
+        toBase64
+            <$> RPC.createPsbt
+                (inputsA fixture)
+                (outputsA fixture)
+                (Just 5)
+                (Just True)
+
+    RPC.analyzePsbt psbtA
+
+    psbtB <-
+        toBase64
+            <$> RPC.createPsbt
+                (inputsB fixture)
+                (outputsB fixture)
+                (Just 5)
+                (Just True)
+
+    RPC.utxoUpdatePsbt psbtA $ descriptorsA fixture
+
+    psbtC <- toBase64 <$> RPC.joinPsbts [psbtA, psbtB]
+    RPC.finalizePsbt psbtC Nothing
+
+    void . withWallet wallet $
+        RPC.processPsbt
+            psbtC
+            (Just True)
+            Nothing
+            (Just True)
+  where
+    wallet = "testPSBT"
+
+    toBase64 = encodeBase64 . S.encode

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Bitcoin.Core.Test.Utils (
+    testRpc,
+    bitcoindTest,
+    shouldMatch,
+
+    -- * Wallet
+    createWallet,
+    walletPassword,
+    unlockWallet,
+    initWallet,
+    withWallet,
+    generate,
+    toInput,
+) where
+
+import Data.Functor (void)
+import Network.HTTP.Client (Manager)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
+
+import Bitcoin.Core.RPC (BitcoindClient, LoadWalletResponse, OutputDetails, PsbtInput (PsbtInput))
+import qualified Bitcoin.Core.RPC as RPC
+import Bitcoin.Core.Regtest (NodeHandle)
+import qualified Bitcoin.Core.Regtest as R
+import Control.Monad.IO.Class (liftIO)
+import Data.Text (Text)
+
+testRpc :: String -> BitcoindClient r -> (String, BitcoindClient ())
+testRpc name x = (name, void x)
+
+bitcoindTest :: Manager -> NodeHandle -> (String, BitcoindClient ()) -> TestTree
+bitcoindTest mgr h (name, task) =
+    testCase name $ R.runBitcoind mgr h task >>= either onFail pure
+  where
+    onFail = assertFailure . show
+
+shouldMatch :: (Eq a, Show a) => a -> a -> BitcoindClient ()
+shouldMatch expected seen = liftIO $ seen @?= expected
+
+createWallet :: Text -> BitcoindClient LoadWalletResponse
+createWallet walletName =
+    RPC.createWallet
+        walletName
+        Nothing
+        Nothing
+        walletPassword
+        (Just True)
+        Nothing
+        Nothing
+        Nothing
+
+walletPassword :: Text
+walletPassword = "password"
+
+unlockWallet :: BitcoindClient ()
+unlockWallet = RPC.walletPassphrase walletPassword 10
+
+initWallet :: Text -> BitcoindClient ()
+initWallet name = void $ createWallet name >> RPC.unloadWallet (Just name) Nothing
+
+withWallet :: Text -> BitcoindClient a -> BitcoindClient a
+withWallet name task =
+    RPC.loadWallet name Nothing >> task <* RPC.unloadWallet (Just name) Nothing
+
+generate :: BitcoindClient ()
+generate = do
+    addr <- RPC.getNewAddress Nothing Nothing
+    void $ RPC.generateToAddress 1 addr Nothing
+
+toInput :: OutputDetails -> PsbtInput
+toInput = PsbtInput <$> RPC.outputTxId <*> RPC.outputVOut <*> pure Nothing

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
@@ -1,0 +1,322 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+module Bitcoin.Core.Test.Wallet (
+    walletRPC,
+) where
+
+import Control.Monad (replicateM, replicateM_, when)
+import Control.Monad.IO.Class (liftIO)
+import Data.Functor (void)
+import Data.List (sortOn)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import Haskoin (OutPoint (OutPoint))
+import Network.HTTP.Client (Manager)
+import System.Directory (removeFile)
+import System.IO.Temp (getCanonicalTemporaryDirectory)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, (@?=))
+
+import Bitcoin.Core.RPC (
+    AddressType (..),
+    BitcoindClient,
+    BumpFeeOptions (BumpFeeOptions),
+    CreatePsbtOptions (CreatePsbtOptions),
+    DescriptorRequest (DescriptorRequest),
+    ListUnspentOptions (ListUnspentOptions),
+    OutputDetails,
+    PrevTx (PrevTx),
+    PsbtOutputs (PsbtOutputs),
+    Purpose (PurposeRecv),
+ )
+import qualified Bitcoin.Core.RPC as RPC
+import Bitcoin.Core.Regtest (NodeHandle, Version, nodeVersion, v20_1, v21_1)
+import Bitcoin.Core.Test.Utils (
+    bitcoindTest,
+    createWallet,
+    generate,
+    initWallet,
+    shouldMatch,
+    testRpc,
+    unlockWallet,
+    walletPassword,
+    withWallet,
+ )
+
+walletRPC :: Manager -> NodeHandle -> TestTree
+walletRPC mgr h =
+    testGroup "wallet-rpc" $
+        if v > v20_1
+            then
+                bitcoindTest mgr h
+                    <$> [ testRpc "walletCommands" testWalletCommands
+                        , testRpc "addressCommands" testAddressCommands
+                        , testRpc "transactionCommands" testTransactionCommands
+                        , testRpc "descriptorCommands" $ testDescriptorCommands v
+                        , testRpc "psbtCommands" testPsbtCommands
+                        ]
+            else mempty
+  where
+    v = nodeVersion h
+
+testWalletCommands :: BitcoindClient ()
+testWalletCommands = do
+    loadWalletR <- createWallet walletName
+    liftIO $ RPC.loadWalletName loadWalletR @?= walletName
+
+    RPC.listWallets >>= shouldMatch [walletName] . filter (not . Text.null)
+
+    RPC.unloadWallet (Just walletName) Nothing
+    RPC.listWallets >>= shouldMatch mempty
+
+    RPC.loadWallet walletName Nothing
+    RPC.listWallets >>= shouldMatch [walletName]
+
+    walletInfo <- RPC.getWalletInfo
+    liftIO $ do
+        RPC.walletStateName walletInfo @?= walletName
+        RPC.walletStateTxCount walletInfo @?= 0
+
+    RPC.rescanBlockchain (Just 0) (Just 0)
+    RPC.abortRescan
+
+    RPC.walletLock
+    RPC.walletPassphrase "password" 60
+
+    RPC.setTxFee 1000
+
+    tmpDir <- liftIO getCanonicalTemporaryDirectory
+    let walletDump = tmpDir <> "/wallet-dump"
+    RPC.dumpWallet walletDump
+
+    let walletBackup = tmpDir <> "/wallet-backup"
+    RPC.backupWallet walletBackup
+
+    RPC.walletLock
+    liftIO $ mapM_ removeFile [walletDump, walletBackup]
+    void $ RPC.unloadWallet (Just walletName) Nothing
+  where
+    walletName = "testCreateWallet"
+
+testAddressCommands :: BitcoindClient ()
+testAddressCommands = do
+    mapM_ initWallet [wallet1, wallet2]
+
+    (privKey, someAddress) <- withWallet wallet1 $ do
+        newAddress <- RPC.getNewAddress (Just label1) (Just Bech32)
+        newAddress2 <- RPC.getNewAddress (Just label2) (Just Legacy)
+        newAddress3 <- RPC.getNewAddress (Just label2) (Just P2SHSegwit)
+        newAddress4 <- RPC.getNewAddress (Just label2) Nothing
+
+        RPC.listLabels Nothing >>= shouldMatch [label1, label2]
+        RPC.getAddressesByLabel label1 >>= shouldMatch [(newAddress, PurposeRecv)] . Map.toList
+        RPC.getAddressesByLabel label2
+            >>= shouldMatch
+                ( sortOn
+                    fst
+                    [ (newAddress2, PurposeRecv)
+                    , (newAddress3, PurposeRecv)
+                    , (newAddress4, PurposeRecv)
+                    ]
+                )
+                . Map.toList
+
+        RPC.setLabel newAddress label3
+        RPC.getAddressesByLabel label3 >>= shouldMatch [(newAddress, PurposeRecv)] . Map.toList
+
+        RPC.addMultisigAddress 2 [newAddress2, newAddress3, newAddress4] Nothing Nothing
+        unlockWallet
+        privKey <- RPC.dumpPrivKey newAddress
+
+        signingAddress <- RPC.getNewAddress Nothing (Just Legacy)
+        RPC.signMessage signingAddress "TEST"
+
+        pure (privKey, newAddress2)
+
+    withWallet wallet2 $ do
+        unlockWallet
+        RPC.importPrivKey privKey (Just "priv-test") Nothing
+        RPC.importAddress someAddress (Just "addr-test") (Just True) Nothing
+  where
+    label1 = "account-1"
+    label2 = "account-2"
+    label3 = "account-3"
+
+    wallet1 = "testAddressCommands1"
+    wallet2 = "testAddressCommands2"
+
+testTransactionCommands :: BitcoindClient ()
+testTransactionCommands = do
+    mapM_ initWallet [userWalletA, minerWallet]
+
+    addressA1 <- withWallet userWalletA $ RPC.getNewAddress (Just labelA1) Nothing
+
+    txId <- withWallet minerWallet $ do
+        replicateM_ 200 generate
+        unlockWallet
+        txId <- sendSimple addressA1 sendAmount1 "funding" "user-a"
+        replicateM_ 200 generate
+        pure txId
+
+    addrs <- withWallet userWalletA $ do
+        RPC.getBalances
+        RPC.getBalance Nothing Nothing Nothing >>= shouldMatch sendAmount1
+        RPC.listReceivedByAddress Nothing Nothing Nothing Nothing
+            >>= shouldMatch 1 . length
+        RPC.listReceivedByLabel Nothing Nothing Nothing
+            >>= shouldMatch 1 . length
+        RPC.getAddressInfo addressA1
+        RPC.getRawChangeAddress Nothing
+        RPC.getReceivedByAddress addressA1 Nothing >>= shouldMatch sendAmount1
+        RPC.getReceivedByLabel labelA1 Nothing >>= shouldMatch sendAmount1
+        RPC.getTransaction txId Nothing
+        RPC.listSinceBlock Nothing Nothing Nothing Nothing
+        RPC.listTransactions Nothing Nothing Nothing Nothing
+        replicateM 20 $ RPC.getNewAddress (Just labelA2) Nothing
+
+    withWallet minerWallet $ do
+        unspent <-
+            RPC.listUnspent
+                Nothing
+                Nothing
+                Nothing
+                (Just True)
+                (ListUnspentOptions Nothing Nothing Nothing Nothing)
+        liftIO . assertBool "At least one output" $ (not . null) unspent
+        RPC.lockUnspent False $ toPrevTx <$> unspent
+        RPC.listLockUnspent >>= shouldMatch (toOutPoint <$> unspent)
+
+        unlockWallet
+        RPC.lockUnspent True $ toPrevTx <$> unspent
+        txId2 <-
+            RPC.sendMany
+                (Map.fromList $ (,100_000) <$> addrs)
+                (Just "send-many")
+                mempty
+                (Just True)
+                Nothing
+                Nothing
+                (Just 1)
+        let options =
+                BumpFeeOptions
+                    { RPC.bumpFeeConfTarget = Nothing
+                    , RPC.bumpFeeFeeRate = Just 10
+                    , RPC.bumpFeeReplaceable = True
+                    , RPC.bumpFeeEstimateMode = Nothing
+                    }
+        RPC.psbtBumpFee txId2 (Just options)
+        RPC.bumpFee txId2 (Just options)
+        pure ()
+  where
+    userWalletA = "testTransactionCommands-A"
+    minerWallet = "testTransactionCommands-M"
+
+    labelA1 = "recv-1"
+    labelA2 = "recv-2"
+
+    sendAmount1 = 3_0000_0000
+
+    sendSimple addr amount what to =
+        RPC.sendToAddress
+            addr
+            amount
+            (Just what)
+            (Just to)
+            Nothing
+            (Just True)
+            Nothing
+            Nothing
+            (Just True)
+            (Just 1)
+
+    toPrevTx =
+        PrevTx
+            <$> RPC.outputTxId
+            <*> RPC.outputVOut
+            <*> RPC.outputScriptPubKey
+            <*> pure Nothing
+            <*> pure Nothing
+            <*> RPC.outputAmount
+
+toOutPoint :: OutputDetails -> OutPoint
+toOutPoint = OutPoint <$> RPC.outputTxId <*> fromIntegral . RPC.outputVOut
+
+testDescriptorCommands :: Version -> BitcoindClient ()
+testDescriptorCommands v = do
+    RPC.createWallet walletName Nothing Nothing walletPassword (Just True) (Just True) Nothing Nothing
+    RPC.walletPassphrase walletPassword 30
+    RPC.getNewAddress (Just "internal") Nothing
+    RPC.importDescriptors
+        [ DescriptorRequest
+            theDescriptor
+            Nothing
+            (Just (0, Just 100))
+            Nothing
+            Nothing
+            Nothing
+            (Just "imported-descriptor")
+        ]
+    when (v > v21_1) $ RPC.listDescriptors >>= shouldMatch 2 . length
+    RPC.unloadWallet (Just walletName) Nothing
+    pure ()
+  where
+    walletName = "descriptorWallet"
+    -- Taken from bitcoind descriptor wallet documentation
+    theDescriptor = "pkh([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*)"
+
+testPsbtCommands :: BitcoindClient ()
+testPsbtCommands = do
+    mapM_ initWallet [walletA, walletB, walletC]
+
+    changeAddr <- withWallet walletA $ do
+        replicateM_ 200 generate
+        RPC.getNewAddress (Just "change") Nothing
+
+    utxos <- withWallet walletB $ do
+        replicateM_ 200 generate
+        take 3 . sortOn isConfirmed
+            <$> RPC.listUnspent
+                Nothing
+                Nothing
+                Nothing
+                Nothing
+                (ListUnspentOptions Nothing Nothing Nothing Nothing)
+
+    liftIO $ length utxos @?= 3
+
+    recvAddr <- withWallet walletC $ RPC.getNewAddress Nothing Nothing
+
+    let theAmount = sum (RPC.outputAmount <$> utxos) `quot` 2
+        outputs = PsbtOutputs [(recvAddr, theAmount)] mempty
+        options =
+            CreatePsbtOptions
+                { RPC.createPsbtAddInputs = Just True
+                , RPC.createPsbtChangeAddress = Just changeAddr
+                , RPC.createPsbtChangePosition = Just 1
+                , RPC.createPsbtChangeType = Nothing
+                , RPC.createPsbtIncludeWatching = Just True
+                , RPC.createPsbtLockUnspents = Just True
+                , RPC.createPsbtFeeRate = Just 1
+                , RPC.createPsbtSubtractFee = mempty
+                , RPC.createPsbtReplaceable = Just True
+                , RPC.createPsbtConfTarget = Nothing
+                , RPC.createPsbtEstimateMode = Nothing
+                }
+
+    void . withWallet walletA $ do
+        unlockWallet
+        RPC.createFundedPsbt mempty outputs Nothing (Just options) (Just True)
+  where
+    walletA = "psbtWallet-A"
+    walletB = "psbtWallet-B"
+    walletC = "psbtWallet-C"
+
+    isConfirmed = (> 6) . RPC.outputConfs
+
+-- TODO encryptWallet,
+-- TODO importWallet,
+-- TODO importMulti,
+-- TODO signRawTx,
+-- TODO processPbst

--- a/bitcoind-regtest/test/Main.hs
+++ b/bitcoind-regtest/test/Main.hs
@@ -1,122 +1,24 @@
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedStrings #-}
 
-module Main where
+module Main (main) where
 
-import Control.Monad (replicateM, void, (>=>))
-import Data.Text (Text)
-import Data.Word (Word64)
-import Haskoin.Address (Address (..), addrToText, pubKeyAddr)
-import Haskoin.Block (Block (..), BlockHash)
-import Haskoin.Constants (btcTest)
-import Haskoin.Crypto (Hash160, SecKey)
-import Haskoin.Keys (
-    PubKeyI,
-    derivePubKeyI,
-    secKey,
-    wrapSecKey,
- )
-import Haskoin.Transaction (OutPoint (..), Tx (..), TxHash, txHash)
-import Network.HTTP.Client (defaultManagerSettings, newManager)
-import Test.Tasty (defaultMain)
-import Test.Tasty.HUnit (assertFailure, testCase)
-
-import Bitcoin.Core.RPC
-import Bitcoin.Core.Regtest (NodeHandle, withBitcoind)
-import qualified Bitcoin.Core.Regtest as R
 import Control.Concurrent (threadDelay)
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Test.Tasty (defaultMain, testGroup)
+
+import Bitcoin.Core.Regtest (withBitcoind)
+import Bitcoin.Core.Test.Misc (miscRPC)
+import Bitcoin.Core.Test.PSBT (psbtRPC)
+import Bitcoin.Core.Test.Wallet (walletRPC)
 
 main :: IO ()
-main =
-    defaultMain . testCase "bitcoind-rpc" . withBitcoind 8449 $ \nodeHandle -> do
-        threadDelay 1_000_000
-        bitcoindTests
-            [ testRpc "generatetoaddress" testGenerate
-            , testRpc "getbestblockhash" getBestBlockHash
-            , testRpc "getblockhash" $ getBlockHash 1
-            , testRpc "getblockfilter" $ testBlockFilter
-            , testRpc "getblockheader" testBlockHeader
-            , testRpc "getblock" testBlock
-            , testRpc "getblockcount" getBlockCount
-            , testRpc "getdifficulty" getDifficulty
-            , testRpc "getchaintips" getChainTips
-            , testRpc "getchaintxstats" $ getChainTxStats Nothing Nothing
-            , testRpc "getmempoolinfo" getMempoolInfo
-            , testRpc "getrawmempool" getRawMempool
-            , testRpc "getrawtransaction" testGetTransaction
-            , testRpc "sendrawtransaction" testSendTransaction
-            , testRpc "createOutput" testCreateOutput
-            , testRpc "getmempoolancestors" testMempoolAncestors
-            , testRpc "getmempooldescendants" testMempoolDescendants
-            , testRpc "getpeerinfo" getPeerInfo
-            , testRpc "getconnectioncount" getConnectionCount
-            , testRpc "getnodeaddresses" $ getNodeAddresses (Just 10)
-            , testRpc "getaddednodeinfo" $ getAddedNodeInfo Nothing
-            , testRpc "listbanned" listBanned
-            , testRpc "getnettotals" getNetTotals
-            , testRpc "uptime" uptime
-            , testRpc "addnode" $ addNode "127.0.0.1:8448" Add
-            , testRpc "clearbanned" clearBanned
-            ]
-            nodeHandle
-
-testGenerate :: BitcoindClient [BlockHash]
-testGenerate = generateToAddress 120 addrText Nothing
-
-key :: SecKey
-Just key = secKey "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-pk :: PubKeyI
-pk = derivePubKeyI $ wrapSecKey True key
-
-addr :: Address
-addrHash :: Hash160
-addr@(PubKeyAddress addrHash) = pubKeyAddr pk
-
-addrText :: Text
-Just addrText = addrToText btcTest addr
-
-testBlock :: BitcoindClient Block
-testBlock = getBestBlockHash >>= getBlock
-
-testBlockFilter :: BitcoindClient CompactFilter
-testBlockFilter = getBestBlockHash >>= getBlockFilter
-
-testBlockHeader :: BitcoindClient BlockHeader
-testBlockHeader = getBestBlockHash >>= getBlockHeader
-
-testBlockStats :: BitcoindClient BlockStats
-testBlockStats = getBestBlockHash >>= getBlockStats
-
-testGetTransaction :: BitcoindClient Tx
-testGetTransaction =
-    getBestBlockHash >>= getBlock >>= (`getTransaction` Nothing) . txHash . head . blockTxns
-
-testSendTransaction :: BitcoindClient TxHash
-testSendTransaction = do
-    outp <- head <$> replicateM 101 R.generate
-    let Right (tx, _) = R.spendPackageOutputs [outp] (R.addrs !! 3) R.oneBitcoin
-    sendTransaction tx Nothing
-
-testMempoolAncestors :: BitcoindClient [TxHash]
-testMempoolAncestors = testSendTransaction >>= getMempoolAncestors
-
-testMempoolDescendants :: BitcoindClient [TxHash]
-testMempoolDescendants = testSendTransaction >>= getMempoolAncestors
-
-testCreateOutput :: BitcoindClient (OutPoint, Word64)
-testCreateOutput = R.createOutput (R.addrs !! 4) (2 * R.oneBitcoin)
-
-testRpc :: String -> BitcoindClient r -> (String, BitcoindClient ())
-testRpc name x = (name, void x)
-
-bitcoindTests :: [(String, BitcoindClient ())] -> NodeHandle -> IO ()
-bitcoindTests ts h = do
+main = withBitcoind 8449 $ \nodeHandle -> do
+    threadDelay 1_000_000
     mgr <- newManager defaultManagerSettings
-    let run msg = R.runBitcoind mgr h >=> assertRight msg
-    mapM_ (uncurry run) ts
-
-assertRight :: Show a => String -> Either a b -> IO b
-assertRight msg = either onFail return
-  where
-    onFail e = assertFailure $ msg <> " - " <> show e
+    defaultMain $
+        testGroup
+            "bitcoind-rpc"
+            [ miscRPC mgr nodeHandle
+            , walletRPC mgr nodeHandle
+            , psbtRPC mgr nodeHandle
+            ]

--- a/bitcoind-regtest/test/Main.hs
+++ b/bitcoind-regtest/test/Main.hs
@@ -24,10 +24,12 @@ import Test.Tasty.HUnit (assertFailure, testCase)
 import Bitcoin.Core.RPC
 import Bitcoin.Core.Regtest (NodeHandle, withBitcoind)
 import qualified Bitcoin.Core.Regtest as R
+import Control.Concurrent (threadDelay)
 
 main :: IO ()
 main =
-    defaultMain . testCase "bitcoind-rpc" . withBitcoind 8449 $
+    defaultMain . testCase "bitcoind-rpc" . withBitcoind 8449 $ \nodeHandle -> do
+        threadDelay 1_000_000
         bitcoindTests
             [ testRpc "generatetoaddress" testGenerate
             , testRpc "getbestblockhash" getBestBlockHash
@@ -56,6 +58,7 @@ main =
             , testRpc "addnode" $ addNode "127.0.0.1:8448" Add
             , testRpc "clearbanned" clearBanned
             ]
+            nodeHandle
 
 testGenerate :: BitcoindClient [BlockHash]
 testGenerate = generateToAddress 120 addrText Nothing

--- a/bitcoind-rpc/CHANGELOG.md
+++ b/bitcoind-rpc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for bitcoind-rpc
 
+## 0.3.0.0 -- 2021-??-??
+
+* Add the "Wallet" section of the RPC
+* Add RPC commands concerned with PSBTs
+* Change handling of optional parameters
+* Changes the type used to represent `vout` values
+* Changes the binding of "getrawtransaction" to `getRawTransaction` 
+
 ## 0.2.0.0 -- 2020-11-01 
 
 * Define our own `BlockHeader` type instead of using the one from `haskoin-core`

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -40,6 +40,8 @@ library
         , containers ^>=0.6
         , haskoin-core >=0.17.1 && <0.21
         , http-client >=0.6 && <0.8
+        , http-types ^>=0.12
+        , mtl ^>=2.2
         , scientific ^>=0.3
         , servant >=0.15 && <0.19
         , servant-client >=0.15 && <0.19

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               bitcoind-rpc
-version:            0.2.0.0
+version:            0.3.0.0
 synopsis:           A streamlined interface to bitcoin core using Haskoin types and Servant
 homepage:           https://github.com/bitnomial/bitcoind-rpc
 license:            BSD-3-Clause

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -26,6 +26,8 @@ library
         Bitcoin.Core.RPC.Control
         Bitcoin.Core.RPC.Network
         Bitcoin.Core.RPC.Transactions
+        Bitcoin.Core.RPC.Wallet
+        Data.Aeson.Utils
         Servant.Bitcoind
 
     build-depends:

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -32,16 +32,14 @@ library
           aeson                          >=1.4      && <1.6
         , base                           >=4.12     && <4.15
         , bytestring                     >=0.10     && <0.12
-        , base16-bytestring               <1.0
-        -- ^^ needed due to missing upper bound in haskoin-core
         , bitcoin-compact-filters       ^>=0.1
         , cereal                        ^>=0.5
-        , haskoin-core                   >=0.13.5   && <0.19
+        , haskoin-core                   >=0.17.1   && <0.21
         , http-client                    >=0.6      && <0.8
         , scientific                    ^>=0.3
         , servant                        >=0.15     && <0.19
         , servant-client                 >=0.15     && <0.19
         , servant-jsonrpc-client         >=1.0      && <1.2
         , text                          ^>=1.2
-        , time                           >=1.8      && <1.12
-        , transformers                  ^>=0.5
+        , time                           >=1.8      && <1.13
+        , transformers                   >=0.5      && <0.7

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -29,17 +29,19 @@ library
         Servant.Bitcoind
 
     build-depends:
-          aeson                          >=1.4      && <1.6
-        , base                           >=4.12     && <4.15
-        , bytestring                     >=0.10     && <0.12
-        , bitcoin-compact-filters       ^>=0.1
-        , cereal                        ^>=0.5
-        , haskoin-core                   >=0.17.1   && <0.21
-        , http-client                    >=0.6      && <0.8
-        , scientific                    ^>=0.3
-        , servant                        >=0.15     && <0.19
-        , servant-client                 >=0.15     && <0.19
-        , servant-jsonrpc-client         >=1.0      && <1.2
-        , text                          ^>=1.2
-        , time                           >=1.8      && <1.13
-        , transformers                   >=0.5      && <0.7
+          aeson >=1.4 && <1.6
+        , base >=4.12 && <4.15
+        , base64 ^>=0.4
+        , bytestring >=0.10 && <0.12
+        , bitcoin-compact-filters ^>=0.1
+        , cereal ^>=0.5
+        , containers ^>=0.6
+        , haskoin-core >=0.17.1 && <0.21
+        , http-client >=0.6 && <0.8
+        , scientific ^>=0.3
+        , servant >=0.15 && <0.19
+        , servant-client >=0.15 && <0.19
+        , servant-jsonrpc-client >=1.0 && <1.2
+        , text ^>=1.2
+        , time >=1.8 && <1.13
+        , transformers >=0.5 && <0.7

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -4,6 +4,8 @@
 
  We provide limited access to the bitcoin-core daemon RPC interface.  RPC
  method descriptions come from the bitcoind RPC help pages.
+
+ /WARNING:/ The wallet RPC calls work for @bitcoind@ versions @0.21.0@ and above.
 -}
 module Bitcoin.Core.RPC (
     -- * Interacting with bitcoind
@@ -15,7 +17,7 @@ module Bitcoin.Core.RPC (
     BitcoindException (..),
 
     -- * Transactions
-    getTransaction,
+    getRawTransaction,
     sendRawTransaction,
     sendTransaction,
     testMempoolAccept,
@@ -52,6 +54,59 @@ module Bitcoin.Core.RPC (
     getAddedNodeInfo,
     listBanned,
     getNetTotals,
+
+    -- * Wallet
+    abandonTransaction,
+    abortRescan,
+    AddressType (..),
+    addMultisigAddress,
+    backupWallet,
+    bumpFee,
+    createWallet,
+    dumpPrivKey,
+    dumpWallet,
+    encryptWallet,
+    Purpose (..),
+    getAddressesByLabel,
+    getAddressInfo,
+    getBalance,
+    getBalances,
+    getNewAddress,
+    getRawChangeAddress,
+    getReceivedByAddress,
+    getReceivedByLabel,
+    getTransaction,
+    getWalletInfo,
+    importAddress,
+    importDescriptors,
+    importMulti,
+    importPrivKey,
+    importWallet,
+    listDescriptors,
+    listLabels,
+    listLockUnspent,
+    listReceivedByAddress,
+    listReceivedByLabel,
+    listSinceBlock,
+    listTransactions,
+    listUnspent,
+    listWallets,
+    loadWallet,
+    lockUnspent,
+    psbtBumpFee,
+    rescanBlockchain,
+    FeeEstimationMode (..),
+    sendMany,
+    sendToAddress,
+    setLabel,
+    setTxFee,
+    signMessage,
+    signRawTx,
+    unloadWallet,
+    createFundedPsbt,
+    walletLock,
+    walletPassphrase,
+    processPsbt,
 
     -- * Control
     stop,
@@ -90,6 +145,7 @@ import Bitcoin.Core.RPC.Generating
 import Bitcoin.Core.RPC.Network
 import Bitcoin.Core.RPC.Responses
 import Bitcoin.Core.RPC.Transactions
+import Bitcoin.Core.RPC.Wallet
 import Servant.Bitcoind (
     BitcoindClient,
     BitcoindException (..),

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -20,6 +20,13 @@ module Bitcoin.Core.RPC (
     sendTransaction,
     testMempoolAccept,
 
+    -- * PSBT
+    analyzePsbt,
+    createPsbt,
+    finalizePsbt,
+    joinPsbts,
+    utxoUpdatePsbt,
+
     -- * Blocks
     getBlock,
     getBlockFilter,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -80,7 +80,7 @@ data BlockStats = BlockStats
     , blockStatsMaxFeeRate :: Word32
     , blockStatsMinTxSize :: Word32
     , blockStatsOuts :: Word32
-    , blockStatsSubsidy :: Word32
+    , blockStatsSubsidy :: Word64
     , blockStatsSegwitSize :: Word32
     , blockStastSegwitWeight :: Word32
     , blockStatsSegwitCount :: Word32

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -49,6 +49,12 @@ import Haskoin.Crypto (Hash256)
 import Haskoin.Transaction (TxHash)
 import Servant.API ((:<|>) (..))
 
+import Data.Aeson.Utils (
+    HexEncoded (unHexEncoded),
+    decodeFromHex,
+    toSatoshis,
+    utcTime,
+ )
 import Servant.Bitcoind (
     BitcoindClient,
     BitcoindEndpoint,
@@ -57,13 +63,9 @@ import Servant.Bitcoind (
     DefTrue,
     DefZero,
     F,
-    HexEncoded (..),
     I,
     O,
-    decodeFromHex,
     toBitcoindClient,
-    toSatoshis,
-    utcTime,
  )
 
 data BlockStats = BlockStats
@@ -215,8 +217,8 @@ data MempoolInfo = MempoolInfo
     , mempoolBytes :: Word32
     , mempoolUsage :: Word32
     , mempoolMax :: Word32
-    , mempoolMinFee :: Word32
-    , mempoolMinRelayFee :: Word32
+    , mempoolMinFee :: Word64
+    , mempoolMinRelayFee :: Word64
     }
     deriving (Eq, Show)
 

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Network.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Network.hs
@@ -37,6 +37,7 @@ import Data.Word (Word16, Word32, Word64)
 import Haskoin.Block (BlockHeight)
 import Servant.API ((:<|>) (..))
 
+import Data.Aeson.Utils (toSatoshis, utcTime)
 import Servant.Bitcoind (
     BitcoindClient,
     BitcoindEndpoint,
@@ -45,8 +46,6 @@ import Servant.Bitcoind (
     I,
     O,
     toBitcoindClient,
-    toSatoshis,
-    utcTime,
  )
 
 -- | Commands as understood by 'addNode'
@@ -141,7 +140,7 @@ data PeerInfo = PeerInfo
     , inflight :: [BlockHeight]
     , whitelisted :: Bool
     , -- | in satoshis
-      minFeeFilter :: Word32
+      minFeeFilter :: Word64
     }
     deriving (Eq, Show)
 

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Responses.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Responses.hs
@@ -1,6 +1,13 @@
 module Bitcoin.Core.RPC.Responses (
     -- * Transactions
     MempoolTestResult (..),
+    PsbtInput (..),
+    PsbtOutputs (..),
+    PsbtMissing (..),
+    AnalyzePsbtInput (..),
+    AnalyzePsbtResponse (..),
+    FinalizePsbtResponse (..),
+    Descriptor (..),
 
     -- * Blocks
     CompactFilter (..),

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Responses.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Responses.hs
@@ -27,8 +27,37 @@ module Bitcoin.Core.RPC.Responses (
     NodeInfoAddress (..),
     ConnDir (..),
     NetTotals (..),
+
+    -- * Wallet
+    NewMultisigAddress (..),
+    BumpFeeOptions (..),
+    BumpFeeResponse (..),
+    LoadWalletResponse (..),
+    AddressInfo (..),
+    BalanceDetails (..),
+    Balances (..),
+    Category (..),
+    TransactionDetails (..),
+    GetTransactionResponse (..),
+    WalletStateInfo (..),
+    DescriptorRequest (..),
+    ImportResponse (..),
+    ImportMultiRequest (..),
+    DescriptorDetails (..),
+    ListReceivedResponse (..),
+    ListReceivedByLabelResponse (..),
+    ListSinceBlockResponse (..),
+    ListUnspentOptions (..),
+    OutputDetails (..),
+    RescanResponse (..),
+    PrevTx (..),
+    SignRawTxResponse (..),
+    CreatePsbtOptions (..),
+    CreatePsbtResponse (..),
+    ProcessPsbtResponse (..),
 ) where
 
 import Bitcoin.Core.RPC.Blockchain
 import Bitcoin.Core.RPC.Network
 import Bitcoin.Core.RPC.Transactions
+import Bitcoin.Core.RPC.Wallet

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
@@ -1,32 +1,51 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Bitcoin.Core.RPC.Transactions (
-    getTransaction,
+    getRawTransaction,
     sendRawTransaction,
     sendTransaction,
     MempoolTestResult (..),
     testMempoolAccept,
+
+    -- * PSBT
+    PsbtMissing (..),
+    AnalyzePsbtInput (..),
+    AnalyzePsbtResponse (..),
+    analyzePsbt,
+    PsbtInput (..),
+    PsbtOutputs (..),
+    createPsbt,
+    FinalizePsbtResponse (..),
+    finalizePsbt,
+    joinPsbts,
+    Descriptor (..),
+    utxoUpdatePsbt,
 ) where
 
-import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
+import Data.Aeson (FromJSON (..), ToJSON (toJSON), object, withObject, (.:), (.:?), (.=))
 import Data.Proxy (Proxy (..))
+import Data.Scientific (Scientific)
 import qualified Data.Serialize as S
 import Data.Text (Text)
+import Data.Word (Word64)
 import Haskoin.Block (BlockHash)
-import Haskoin.Transaction (Tx, TxHash)
+import Haskoin.Transaction (PartiallySignedTransaction, Tx, TxHash)
 import Haskoin.Util (encodeHex)
 import Servant.API ((:<|>) (..))
 
 import Data.Aeson.Utils (
+    Base64Encoded,
     HexEncoded (unHexEncoded),
     partialObject,
     rangeToJSON,
     satsPerBTC,
     satsToBTCText,
     toSatoshis,
+    unBase64Encoded,
     (.=?),
  )
 import Servant.Bitcoind (
@@ -55,6 +74,33 @@ type RawTxRpc =
     BitcoindEndpoint "sendrawtransaction" (I Text -> O Double -> C TxHash)
         :<|> BitcoindEndpoint "getrawtransaction" (I TxHash -> F DefFalse Bool -> O BlockHash -> C (HexEncoded Tx))
         :<|> BitcoindEndpoint "testmempoolaccept" (I [Tx] -> O Double -> C [MempoolTestResult])
+        :<|> BitcoindEndpoint "analyzepsbt" (I Text -> C AnalyzePsbtResponse)
+        :<|> BitcoindEndpoint
+                "createpsbt"
+                ( I [PsbtInput] ->
+                  I PsbtOutputs ->
+                  O Int ->
+                  O Bool ->
+                  C (Base64Encoded PartiallySignedTransaction)
+                )
+        :<|> BitcoindEndpoint
+                "finalizepsbt"
+                ( I Text ->
+                  O Bool ->
+                  C FinalizePsbtResponse
+                )
+        :<|> BitcoindEndpoint "joinpsbts" (I [Text] -> C (Base64Encoded PartiallySignedTransaction))
+        :<|> BitcoindEndpoint "utxoupdatepsbt" (I Text -> I [Descriptor] -> C (Base64Encoded PartiallySignedTransaction))
+
+sendRawTransaction
+    :<|> getRawTransaction'
+    :<|> testMempoolAccept
+    :<|> analyzePsbt
+    :<|> createPsbt_
+    :<|> finalizePsbt
+    :<|> joinPsbts_
+    :<|> utxoUpdatePsbt_ =
+        toBitcoindClient $ Proxy @RawTxRpc
 
 -- | Submit a raw transaction (serialized, hex-encoded) to local node and network.
 sendRawTransaction :: Text -> Maybe Double -> BitcoindClient TxHash
@@ -63,14 +109,13 @@ sendRawTransaction :: Text -> Maybe Double -> BitcoindClient TxHash
 sendTransaction :: Tx -> Maybe Double -> BitcoindClient TxHash
 sendTransaction = sendRawTransaction . encodeHex . S.encode
 
-getTransaction' :: TxHash -> Maybe BlockHash -> BitcoindClient (HexEncoded Tx)
+getRawTransaction' :: TxHash -> Maybe BlockHash -> BitcoindClient (HexEncoded Tx)
 
 {- | Returns result of mempool acceptance tests indicating if the transactions
  would be accepted by mempool.  This checks if the transaction violates the
  consensus or policy rules.
 -}
 testMempoolAccept :: [Tx] -> Maybe Double -> BitcoindClient [MempoolTestResult]
-sendRawTransaction :<|> getTransaction' :<|> testMempoolAccept = toBitcoindClient $ Proxy @RawTxRpc
 
 {- | By default this function only works for mempool transactions. When called
  with a blockhash argument, getrawtransaction will return the transaction if
@@ -79,5 +124,219 @@ sendRawTransaction :<|> getTransaction' :<|> testMempoolAccept = toBitcoindClien
  transaction if it is in the mempool, or if -txindex is enabled and the
  transaction is in a block in the blockchain.
 -}
-getTransaction :: TxHash -> Maybe BlockHash -> BitcoindClient Tx
-getTransaction h = fmap unHexEncoded . getTransaction' h
+getRawTransaction :: TxHash -> Maybe BlockHash -> BitcoindClient Tx
+getRawTransaction h = fmap unHexEncoded . getRawTransaction' h
+
+-- | @since 0.3.0.0
+data PsbtMissing = PsbtMissing
+    { -- | Public key ID, hash160 of the public key, of a public key whose BIP 32 derivation path is missing
+      missingPubkeys :: [Text]
+    , -- | Public key ID, hash160 of the public key, of a public key whose signature is missing
+      missingSigs :: [Text]
+    , -- | Hash160 of the redeemScript that is missing
+      redeemScript :: Maybe Text
+    , -- | SHA256 of the witnessScript that is missing
+      witnessScript :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON PsbtMissing where
+    parseJSON = withObject "PsbtMissing" $ \obj ->
+        PsbtMissing
+            <$> obj .: "pubkeys"
+            <*> obj .: "signatures"
+            <*> obj .:? "redeemscript"
+            <*> obj .:? "witnessscript"
+
+-- | @since 0.3.0.0
+data AnalyzePsbtInput = AnalyzePsbtInput
+    { -- | Whether a UTXO is provided
+      hasUtxo :: Bool
+    , -- | Whether the input is finalized
+      isFinal :: Bool
+    , missing :: Maybe PsbtMissing
+    , -- | Role of the next person that this input needs to go to
+      next :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AnalyzePsbtInput where
+    parseJSON = withObject "AnalyzePsbtInput" $ \obj ->
+        AnalyzePsbtInput
+            <$> obj .: "has_utxo"
+            <*> obj .: "is_final"
+            <*> obj .:? "missing"
+            <*> obj .:? "next"
+
+-- | @since 0.3.0.0
+data AnalyzePsbtResponse = AnalyzePsbtResponse
+    { analysePsbtInput :: [AnalyzePsbtInput]
+    , -- | Estimated vsize of the final signed transaction
+      analyzePsbtEstimatedVSize :: Maybe Int
+    , -- | Estimated feerate of the final signed transaction in sats/kB. Shown only if all UTXO slots in the PSBT have been filled.
+      analyzePsbtEstimatedFeeRate :: Maybe Scientific
+    , -- | The transaction fee paid. Shown only if all UTXO slots in the PSBT have been filled.
+      analyzePsbtFee :: Maybe Word64
+    , -- | Role of the next person that this psbt needs to go to
+      analyzePsbtNext :: Maybe Text
+    , -- | Error message if there is one
+      analyzePsbtError :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AnalyzePsbtResponse where
+    parseJSON = withObject "AnalyzePsbtResponse" $ \obj ->
+        AnalyzePsbtResponse
+            <$> obj .: "inputs"
+            <*> obj .:? "estimated_vsize"
+            <*> (fmap (* satsPerBTC) <$> obj .:? "estimated_feerate")
+            <*> (fmap toSatoshis <$> obj .:? "fee")
+            <*> obj .:? "next"
+            <*> obj .:? "error"
+
+{- | Analyzes and provides information about the current status of a PSBT and its inputs
+
+  @since 0.3.0.0
+-}
+analyzePsbt ::
+    -- | A base64 string of a PSBT
+    Text ->
+    BitcoindClient AnalyzePsbtResponse
+
+-- | @since 0.3.0.0
+data PsbtInput = PsbtInput
+    { -- | The transaction id
+      psbtInputTx :: TxHash
+    , -- | The output number
+      psbtInputVOut :: Int
+    , -- | The sequence number
+      psbtInputSequence :: Maybe Int
+    }
+    deriving (Eq, Show)
+
+instance ToJSON PsbtInput where
+    toJSON input =
+        partialObject
+            [ Just $ "txid" .= psbtInputTx input
+            , Just $ "vout" .= psbtInputVOut input
+            , "sequence" .=? psbtInputSequence input
+            ]
+
+-- | @since 0.3.0.0
+data PsbtOutputs = PsbtOutputs
+    { psbtOutputAddrs :: [(Text, Word64)]
+    , psbtOutputData :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance ToJSON PsbtOutputs where
+    toJSON outputs =
+        toJSON $
+            (fmap toAddrObject . psbtOutputAddrs) outputs
+                <> (foldMap toDataObject . psbtOutputData) outputs
+      where
+        toAddrObject (addr, amount) = object [addr .= satsToBTCText amount]
+        toDataObject hex = [object ["data" .= hex]]
+
+{- | Creates a transaction in the Partially Signed Transaction format. Implements the Creator role.
+
+ @since 0.3.0.0
+-}
+createPsbt ::
+    [PsbtInput] ->
+    PsbtOutputs ->
+    -- | Raw locktime. Non-0 value also locktime-activates inputs
+    Maybe Int ->
+    -- | Marks this transaction as BIP125 replaceable.
+    Maybe Bool ->
+    BitcoindClient PartiallySignedTransaction
+createPsbt inputs outputs locktime = fmap unBase64Encoded . createPsbt_ inputs outputs locktime
+
+createPsbt_ ::
+    [PsbtInput] ->
+    PsbtOutputs ->
+    Maybe Int ->
+    Maybe Bool ->
+    BitcoindClient (Base64Encoded PartiallySignedTransaction)
+
+-- | @since 0.3.0.0
+data FinalizePsbtResponse = FinalizePsbtResponse
+    { -- | The base64-encoded partially signed transaction if not extracted
+      finalizedPsbt :: Maybe PartiallySignedTransaction
+    , -- | The hex-encoded network transaction if extracted
+      finalizedTx :: Maybe Tx
+    , -- | If the transaction has a complete set of signatures
+      finalizeComplete :: Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON FinalizePsbtResponse where
+    parseJSON = withObject "FinalizePsbtResponse" $ \obj ->
+        FinalizePsbtResponse
+            <$> (fmap unBase64Encoded <$> obj .:? "psbt")
+            <*> (fmap unHexEncoded <$> obj .:? "hex")
+            <*> obj .: "complete"
+
+{- | Finalize the inputs of a PSBT. If the transaction is fully signed, it will
+ produce a network serialized transaction which can be broadcast with
+ sendrawtransaction. Otherwise a PSBT will be created which has the
+ final_scriptSig and final_scriptWitness fields filled for inputs that are
+ complete.  Implements the Finalizer and Extractor roles.
+
+ @since 0.3.0.0
+-}
+finalizePsbt ::
+    -- | A base64 string of a PSBT
+    Text ->
+    -- | If true and the transaction is complete, extract and return the
+    -- complete transaction in normal network serialization instead of the PSBT.
+    Maybe Bool ->
+    BitcoindClient FinalizePsbtResponse
+
+{- | Joins multiple distinct PSBTs with different inputs and outputs into one
+ PSBT with inputs and outputs from all of the PSBTs No input in any of the PSBTs
+ can be in more than one of the PSBTs.
+
+ @since 0.3.0.0
+-}
+joinPsbts ::
+    -- | A base64 string of a PSBT
+    [Text] ->
+    BitcoindClient PartiallySignedTransaction
+joinPsbts = fmap unBase64Encoded . joinPsbts_
+
+joinPsbts_ ::
+    [Text] ->
+    BitcoindClient (Base64Encoded PartiallySignedTransaction)
+
+-- | @since 0.3.0.0
+data Descriptor
+    = Descriptor Text
+    | RangedDescriptor Text (Int, Maybe Int)
+    deriving (Eq, Show)
+
+instance ToJSON Descriptor where
+    toJSON = \case
+        Descriptor theDescriptor -> toJSON theDescriptor
+        RangedDescriptor theDescriptor range ->
+            object
+                [ "desc" .= theDescriptor
+                , "range" .= rangeToJSON range
+                ]
+
+{- | Updates all segwit inputs and outputs in a PSBT with data from output
+ descriptors, the UTXO set or the mempool.
+
+ @since 0.3.0.0
+-}
+utxoUpdatePsbt ::
+    -- | A base64 string of a PSBT
+    Text ->
+    [Descriptor] ->
+    BitcoindClient PartiallySignedTransaction
+utxoUpdatePsbt psbt = fmap unBase64Encoded . utxoUpdatePsbt_ psbt
+
+utxoUpdatePsbt_ ::
+    Text ->
+    [Descriptor] ->
+    BitcoindClient (Base64Encoded PartiallySignedTransaction)

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
@@ -20,13 +20,21 @@ import Haskoin.Transaction (Tx, TxHash)
 import Haskoin.Util (encodeHex)
 import Servant.API ((:<|>) (..))
 
+import Data.Aeson.Utils (
+    HexEncoded (unHexEncoded),
+    partialObject,
+    rangeToJSON,
+    satsPerBTC,
+    satsToBTCText,
+    toSatoshis,
+    (.=?),
+ )
 import Servant.Bitcoind (
     BitcoindClient,
     BitcoindEndpoint,
     C,
     DefFalse,
     F,
-    HexEncoded (..),
     I,
     O,
     toBitcoindClient,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
@@ -31,7 +31,7 @@ import Data.Proxy (Proxy (..))
 import Data.Scientific (Scientific)
 import qualified Data.Serialize as S
 import Data.Text (Text)
-import Data.Word (Word64)
+import Data.Word (Word32, Word64)
 import Haskoin.Block (BlockHash)
 import Haskoin.Transaction (PartiallySignedTransaction, Tx, TxHash)
 import Haskoin.Util (encodeHex)
@@ -208,7 +208,7 @@ data PsbtInput = PsbtInput
     { -- | The transaction id
       psbtInputTx :: TxHash
     , -- | The output number
-      psbtInputVOut :: Int
+      psbtInputVOut :: Word32
     , -- | The sequence number
       psbtInputSequence :: Maybe Int
     }

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
@@ -108,7 +108,7 @@ import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (NominalDiffTime, UTCTime)
-import Data.Word (Word64)
+import Data.Word (Word32, Word64)
 import Haskoin (
     BlockHash,
     BlockHeight,
@@ -906,7 +906,7 @@ data GetTxOutputDetails = GetTxOutputDetails
     , -- | A comment for the address/transaction, if any
       getTxLabel :: Maybe Text
     , -- | the vout value
-      getTxVout :: Int
+      getTxVout :: Word32
     , getTxOutputFee :: Maybe Word64
     , -- | 'true' if the transaction has been abandoned (inputs are respendable). Only
       -- available for the 'send' category of transactions.
@@ -1446,7 +1446,7 @@ data TransactionDetails = TransactionDetails
     , -- | A comment for the address/transaction, if any
       txDetailsLabel :: Maybe Text
     , -- | The vout value
-      txDetailsVout :: Int
+      txDetailsVout :: Word32
     , -- | The amount of the fee in sats. This is only available for
       -- the 'send' category of transactions.
       txDetailsFee :: Maybe Word64
@@ -1593,7 +1593,7 @@ data OutputDetails = OutputDetails
     { -- | the transaction id
       outputTxId :: TxHash
     , -- | the vout value
-      outputVOut :: Int
+      outputVOut :: Word32
     , -- | the bitcoin address
       outputAddress :: Text
     , -- | The associated label, or "" for the default label
@@ -1892,7 +1892,7 @@ data PrevTx = PrevTx
     { -- | The transaction id
       prevTxId :: TxHash
     , -- | The output number
-      prevTxVOut :: Int
+      prevTxVOut :: Word32
     , -- | script key
       prevTxScriptPubKey :: Text
     , -- | redeem script (required for P2SH)
@@ -1917,7 +1917,7 @@ instance ToJSON PrevTx where
 
 data SignRawTxError = SignRawTxError
     { signRawTxErrorTxId :: TxHash
-    , signRawTxErrorVOut :: Int
+    , signRawTxErrorVOut :: Word32
     , signRawTxErrorScriptSig :: Text
     , signRawTxErrorSequence :: Int
     , signRawTxError :: Text
@@ -2042,8 +2042,7 @@ instance ToJSON CreatePsbtOptions where
 
 -- | @since 0.3.0.0
 data CreatePsbtResponse = CreatePsbtResponse
-    { -- | The resulting raw transaction (base64-encoded string)
-      createPsbtPsbt :: Text
+    { createPsbtPsbt :: PartiallySignedTransaction
     , -- | Fee in sats the resulting transaction pays
       createPsbtFee :: Word64
     , -- | The position of the added change output, or -1
@@ -2054,7 +2053,7 @@ data CreatePsbtResponse = CreatePsbtResponse
 instance FromJSON CreatePsbtResponse where
     parseJSON = withObject "CreatePsbtResponse" $ \obj ->
         CreatePsbtResponse
-            <$> obj .: "psbt"
+            <$> (unBase64Encoded <$> obj .: "psbt")
             <*> (toSatoshis <$> obj .: "fee")
             <*> obj .: "changepos"
 

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
@@ -1,0 +1,2144 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+{- |
+ Module: Bitcoin.Core.RPC.Wallet
+
+ Wallet related functionality
+-}
+module Bitcoin.Core.RPC.Wallet (
+    abandonTransaction,
+    abortRescan,
+    AddressType (..),
+    NewMultisigAddress (..),
+    addMultisigAddress,
+    backupWallet,
+    BumpFeeOptions (..),
+    BumpFeeResponse (..),
+    bumpFee,
+    LoadWalletResponse (..),
+    createWallet,
+    dumpPrivKey,
+    dumpWallet,
+    encryptWallet,
+    Purpose (..),
+    getAddressesByLabel,
+    AddressInfo (..),
+    getAddressInfo,
+    getBalance,
+    BalanceDetails (..),
+    Balances (..),
+    getBalances,
+    getNewAddress,
+    getRawChangeAddress,
+    getReceivedByAddress,
+    getReceivedByLabel,
+    Category (..),
+    TransactionDetails (..),
+    GetTransactionResponse (..),
+    getTransaction,
+    WalletStateInfo (..),
+    getWalletInfo,
+    importAddress,
+    DescriptorRequest (..),
+    ImportResponse (..),
+    importDescriptors,
+    ImportMultiRequest (..),
+    importMulti,
+    importPrivKey,
+    importWallet,
+    DescriptorDetails (..),
+    listDescriptors,
+    listLabels,
+    listLockUnspent,
+    ListReceivedResponse (..),
+    listReceivedByAddress,
+    ListReceivedByLabelResponse (..),
+    listReceivedByLabel,
+    ListSinceBlockResponse (..),
+    listSinceBlock,
+    listTransactions,
+    ListUnspentOptions (..),
+    OutputDetails (..),
+    listUnspent,
+    listWallets,
+    loadWallet,
+    lockUnspent,
+    psbtBumpFee,
+    RescanResponse (..),
+    rescanBlockchain,
+    FeeEstimationMode (..),
+    sendMany,
+    sendToAddress,
+    setLabel,
+    setTxFee,
+    signMessage,
+    PrevTx (..),
+    SignRawTxResponse (..),
+    signRawTx,
+    unloadWallet,
+    CreatePsbtOptions (..),
+    CreatePsbtResponse (..),
+    createFundedPsbt,
+    walletLock,
+    walletPassphrase,
+    ProcessPsbtResponse (..),
+    processPsbt,
+) where
+
+import Data.Aeson (
+    FromJSON (..),
+    ToJSON (..),
+    Value (Object),
+    object,
+    withObject,
+    withText,
+    (.:),
+    (.:?),
+    (.=),
+ )
+import Data.Map.Strict (Map)
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (Proxy))
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time (NominalDiffTime, UTCTime)
+import Data.Word (Word64)
+import Haskoin (
+    BlockHash,
+    BlockHeight,
+    DerivPath,
+    Hash160,
+    OutPoint (OutPoint),
+    PartiallySignedTransaction,
+    Tx,
+    TxHash,
+ )
+import Servant.API ((:<|>) (..))
+
+import Bitcoin.Core.RPC.Transactions (PsbtInput, PsbtOutputs)
+import Data.Aeson.Utils (
+    partialObject,
+    rangeToJSON,
+    satsToBTCText,
+    toSatoshis,
+    unBase64Encoded,
+    unHexEncoded,
+    utcTime,
+    (.=?),
+ )
+import Servant.Bitcoind (
+    BitcoindClient,
+    BitcoindEndpoint,
+    C,
+    CX,
+    DefFalse,
+    DefZero,
+    EmptyString,
+    F,
+    I,
+    O,
+    toBitcoindClient,
+ )
+
+type WalletRpc =
+    BitcoindEndpoint "abandontransaction" (I TxHash -> CX)
+        :<|> BitcoindEndpoint "abortrescan" (C Bool)
+        :<|> BitcoindEndpoint
+                "addmultisigaddress"
+                ( I Int ->
+                  I [Text] ->
+                  O Text ->
+                  O AddressType ->
+                  C NewMultisigAddress
+                )
+        :<|> BitcoindEndpoint "backupwallet" (I FilePath -> CX)
+        :<|> BitcoindEndpoint "bumpfee" (I TxHash -> O BumpFeeOptions -> C BumpFeeResponse)
+        :<|> BitcoindEndpoint
+                "createwallet"
+                ( I Text ->
+                  O Bool ->
+                  O Bool ->
+                  I Text ->
+                  O Bool ->
+                  O Bool ->
+                  O Bool ->
+                  O Bool ->
+                  C LoadWalletResponse
+                )
+        :<|> BitcoindEndpoint "dumpprivkey" (I Text -> C Text)
+        :<|> BitcoindEndpoint "dumpwallet" (I FilePath -> C DumpWalletResponse)
+        :<|> BitcoindEndpoint "encryptwallet" (I Text -> C Text)
+        :<|> BitcoindEndpoint "getaddressesbylabel" (I Text -> C (Map Text Purpose))
+        :<|> BitcoindEndpoint "getaddressinfo" (I Text -> C AddressInfo)
+        :<|> BitcoindEndpoint "getbalance" (O Text -> O Int -> O Bool -> O Bool -> C Scientific)
+        :<|> BitcoindEndpoint "getbalances" (C Balances)
+        :<|> BitcoindEndpoint "getnewaddress" (O Text -> O AddressType -> C Text)
+        :<|> BitcoindEndpoint "getrawchangeaddress" (O AddressType -> C Text)
+        :<|> BitcoindEndpoint "getreceivedbyaddress" (I Text -> O Int -> C Scientific)
+        :<|> BitcoindEndpoint "getreceivedbylabel" (I Text -> O Int -> C Scientific)
+        :<|> BitcoindEndpoint
+                "gettransaction"
+                ( I TxHash ->
+                  O Bool ->
+                  F DefFalse Bool ->
+                  C GetTransactionResponse
+                )
+        :<|> BitcoindEndpoint "getwalletinfo" (C WalletStateInfo)
+        :<|> BitcoindEndpoint "importaddress" (I Text -> O Text -> O Bool -> O Bool -> CX)
+        :<|> BitcoindEndpoint "importdescriptors" (I [DescriptorRequest] -> C [ImportResponse])
+        :<|> BitcoindEndpoint "importmulti" (I [ImportMultiRequest] -> O ImportMultiOptions -> C [ImportResponse])
+        :<|> BitcoindEndpoint "importprivkey" (I Text -> O Text -> O Bool -> CX)
+        -- WAIT importprunedfunds "rawtransaction" "txoutproof"
+        --      :<|> BitcoindEndpoint "importprunedfunds" ()
+        -- WAIT importpubkey "pubkey" ( "label" rescan )
+        --      :<|> BitcoindEndpoint "importpubkey" ()
+        :<|> BitcoindEndpoint "importwallet" (I FilePath -> CX)
+        -- WAIT keypoolrefill ( newsize )
+        --      :<|> BitcoindEndpoint "keypoolrefill" ()
+        -- WAIT listaddressgroupings
+        --      :<|> BitcoindEndpoint "listaddressgroupings" ()
+        :<|> BitcoindEndpoint "listdescriptors" (C [DescriptorDetails])
+        :<|> BitcoindEndpoint "listlabels" (O Text -> C [Text])
+        :<|> BitcoindEndpoint "listlockunspent" (C [JsonOutPoint])
+        :<|> BitcoindEndpoint
+                "listreceivedbyaddress"
+                ( O Int ->
+                  O Bool ->
+                  O Bool ->
+                  O Text ->
+                  C [ListReceivedResponse]
+                )
+        :<|> BitcoindEndpoint
+                "listreceivedbylabel"
+                ( O Int ->
+                  O Bool ->
+                  O Bool ->
+                  C [ListReceivedByLabelResponse]
+                )
+        :<|> BitcoindEndpoint
+                "listsinceblock"
+                ( O BlockHash ->
+                  O Int ->
+                  O Bool ->
+                  O Bool ->
+                  C ListSinceBlockResponse
+                )
+        :<|> BitcoindEndpoint
+                "listtransactions"
+                ( O Text ->
+                  O Int ->
+                  O Int ->
+                  O Bool ->
+                  C [TransactionDetails]
+                )
+        :<|> BitcoindEndpoint
+                "listunspent"
+                ( O Int ->
+                  O Int ->
+                  O [Text] ->
+                  O Bool ->
+                  I ListUnspentOptions ->
+                  C [OutputDetails]
+                )
+        -- WAIT listwalletdir
+        --      :<|> BitcoindEndpoint "listwalletdir" ()
+        :<|> BitcoindEndpoint "listwallets" (C [Text])
+        :<|> BitcoindEndpoint "loadwallet" (I Text -> O Bool -> C LoadWalletResponse)
+        :<|> BitcoindEndpoint "lockunspent" (I Bool -> I [PrevTx] -> C Bool)
+        :<|> BitcoindEndpoint "psbtbumpfee" (I TxHash -> O BumpFeeOptions -> C BumpFeeResponse)
+        -- WAIT removeprunedfunds "txid"
+        --      :<|> BitcoindEndpoint "removeprunedfunds" ()
+        :<|> BitcoindEndpoint
+                "rescanblockchain"
+                ( O BlockHeight ->
+                  O BlockHeight ->
+                  C RescanResponse
+                )
+        -- WAIT send [{"address":amount},{"data":"hex"},...] ( conf_target "estimate_mode" fee_rate options )
+        --      :<|> BitcoindEndpoint "send" ()
+        :<|> BitcoindEndpoint
+                "sendmany"
+                ( F EmptyString Text ->
+                  I (Map Text Text) ->
+                  F DefZero Int ->
+                  O Text ->
+                  I [Text] ->
+                  O Bool ->
+                  O Int ->
+                  O FeeEstimationMode ->
+                  O Word64 ->
+                  F DefFalse Bool ->
+                  C TxHash
+                )
+        :<|> BitcoindEndpoint
+                "sendtoaddress"
+                ( I Text ->
+                  I Text ->
+                  O Text ->
+                  O Text ->
+                  O Bool ->
+                  O Bool ->
+                  O Int ->
+                  O FeeEstimationMode ->
+                  O Bool ->
+                  O Word64 ->
+                  F DefFalse Bool ->
+                  C TxHash
+                )
+        -- WAIT sethdseed ( newkeypool "seed" )
+        --      :<|> BitcoindEndpoint "sethdseed" ()
+        :<|> BitcoindEndpoint "setlabel" (I Text -> I Text -> CX)
+        :<|> BitcoindEndpoint "settxfee" (I Text -> C Bool)
+        -- WAIT setwalletflag "flag" ( value )
+        --      :<|> BitcoindEndpoint "setwalletflag" ()
+        :<|> BitcoindEndpoint "signmessage" (I Text -> I Text -> C Text)
+        :<|> BitcoindEndpoint
+                "signrawtransactionwithwallet"
+                ( I Text ->
+                  I [PrevTx] ->
+                  O Text ->
+                  C SignRawTxResponse
+                )
+        :<|> BitcoindEndpoint "unloadwallet" (O Text -> O Bool -> C UnloadWalletResponse)
+        -- WAIT upgradewallet ( version )
+        --      :<|> BitcoindEndpoint "upgradewallet" ()
+        :<|> BitcoindEndpoint
+                "walletcreatefundedpsbt"
+                ( I [PsbtInput] ->
+                  I PsbtOutputs ->
+                  O Int ->
+                  O CreatePsbtOptions ->
+                  O Bool ->
+                  C CreatePsbtResponse
+                )
+        -- WAIT walletlock
+        :<|> BitcoindEndpoint "walletlock" CX
+        :<|> BitcoindEndpoint "walletpassphrase" (I Text -> I Int -> CX)
+        -- WAIT walletpassphrasechange "oldpassphrase" "newpassphrase"
+        --      :<|> BitcoindEndpoint "walletpassphrasechange" ()
+        :<|> BitcoindEndpoint
+                "walletprocesspsbt"
+                ( I Text ->
+                  O Bool ->
+                  I Text ->
+                  O Bool ->
+                  C ProcessPsbtResponse
+                )
+
+-- client definition
+abandonTransaction
+    :<|> abortRescan
+    :<|> addMultisigAddress
+    :<|> backupWallet
+    :<|> bumpFee
+    :<|> createWallet
+    :<|> dumpPrivKey
+    :<|> dumpWallet_
+    :<|> encryptWallet
+    :<|> getAddressesByLabel
+    :<|> getAddressInfo
+    :<|> getBalance_
+    :<|> getBalances
+    :<|> getNewAddress
+    :<|> getRawChangeAddress
+    :<|> getReceivedByAddress_
+    :<|> getReceivedByLabel_
+    :<|> getTransaction
+    :<|> getWalletInfo
+    :<|> importAddress
+    :<|> importDescriptors
+    :<|> importMulti_
+    :<|> importPrivKey
+    :<|> importWallet
+    :<|> listDescriptors
+    :<|> listLabels_
+    :<|> listLockUnspent_
+    :<|> listReceivedByAddress
+    :<|> listReceivedByLabel
+    :<|> listSinceBlock
+    :<|> listTransactions
+    :<|> listUnspent
+    :<|> listWallets
+    :<|> loadWallet
+    :<|> lockUnspent
+    :<|> psbtBumpFee
+    :<|> rescanBlockchain
+    :<|> sendMany_
+    :<|> sendToAddress_
+    :<|> setLabel
+    :<|> setTxFee_
+    :<|> signMessage
+    :<|> signRawTx
+    :<|> unloadWallet_
+    :<|> createFundedPsbt
+    :<|> walletLock
+    :<|> walletPassphrase
+    :<|> processPsbt_ =
+        toBitcoindClient $ Proxy @WalletRpc
+
+{- | Mark in-wallet transaction <txid> as abandoned This will mark this
+ transaction and all its in-wallet descendants as abandoned which will allow for
+ their inputs to be respent.  It can be used to replace "stuck" or evicted
+ transactions.  It only works on transactions which are not included in a block
+ and are not currently in the mempool.  It has no effect on transactions which
+ are already abandoned.
+
+ @since 0.3.0.0
+-}
+abandonTransaction ::
+    -- | The transaction id
+    TxHash ->
+    BitcoindClient ()
+
+{- | Stops current wallet rescan triggered by an RPC call, e.g. by an
+ importprivkey call.  Note: Use "getwalletinfo" to query the scanning progress.
+
+ @since 0.3.0.0
+-}
+abortRescan ::
+    -- | Whether the abort was successful
+    BitcoindClient Bool
+
+-- | @since 0.3.0.0
+data NewMultisigAddress = NewMultisigAddress
+    { -- | The value of the new multisig address
+      newMultisigAddress :: Text
+    , -- | The string value of the hex-encoded redemption script
+      newMultisigRedeemScript :: Text
+    , -- | The descriptor for this multisig
+      newMultisigDescriptor :: Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON NewMultisigAddress where
+    parseJSON = withObject "NewMultisigAddress" $ \obj ->
+        NewMultisigAddress
+            <$> obj .: "address"
+            <*> obj .: "redeemScript"
+            <*> obj .: "descriptor"
+
+-- | @since 0.3.0.0
+data AddressType = Legacy | P2SHSegwit | Bech32
+    deriving (Eq, Show)
+
+instance ToJSON AddressType where
+    toJSON =
+        toJSON @Text . \case
+            Legacy -> "legacy"
+            P2SHSegwit -> "p2sh-segwit"
+            Bech32 -> "bech32"
+
+{- | Add an nrequired-to-sign multisignature address to the wallet. Requires a
+ new wallet backup.  Each key is a Bitcoin address or hex-encoded public key.
+ This functionality is only intended for use with non-watchonly addresses.  See
+ `importaddress` for watchonly p2sh address support.  If 'label' is specified,
+ assign address to that label.
+
+ @since 0.3.0.0
+-}
+addMultisigAddress ::
+    -- | The number of required signatures out of the n keys or addresses.
+    Int ->
+    -- | The bitcoin addresses or hex-encoded public keys
+    [Text] ->
+    -- | A label to assign the addresses to.
+    Maybe Text ->
+    Maybe AddressType ->
+    BitcoindClient NewMultisigAddress
+
+{- | Safely copies current wallet file to destination, which can be a directory
+ or a path with filename.
+
+ @since 0.3.0.0
+-}
+backupWallet ::
+    -- | The destination directory or file
+    FilePath ->
+    BitcoindClient ()
+
+-- | @since 0.3.0.0
+data BumpFeeOptions = BumpFeeOptions
+    { -- | Confirmation target in blocks
+      bumpFeeConfTarget :: Maybe Int
+    , -- | Specify a fee rate in sat/vB instead of relying on the built-in fee estimator.
+      -- Must be at least 1.000 sat/vB higher than the current transaction fee rate.
+      bumpFeeFeeRate :: Maybe Scientific
+    , -- | Whether the new transaction should still be
+      -- marked bip-125 replaceable. If true, the sequence numbers in the transaction will
+      -- be left unchanged from the original. If false, any input sequence numbers in the
+      -- original transaction that were less than 0xfffffffe will be increased to 0xfffffffe
+      -- so the new transaction will not be explicitly bip-125 replaceable (though it may
+      -- still be replaceable in practice, for example if it has unconfirmed ancestors which
+      -- are replaceable).
+      bumpFeeReplaceable :: Bool
+    , bumpFeeEstimateMode :: Maybe FeeEstimationMode
+    }
+    deriving (Eq, Show)
+
+instance ToJSON BumpFeeOptions where
+    toJSON opts =
+        partialObject
+            [ "conf_target" .=? bumpFeeConfTarget opts
+            , "fee_rate" .=? bumpFeeFeeRate opts
+            , Just $ "replaceable" .= bumpFeeReplaceable opts
+            , "estimate_mode" .=? bumpFeeEstimateMode opts
+            ]
+
+-- | @since 0.3.0.0
+data BumpFeeResponse = BumpFeeResponse
+    { -- | The base64-encoded unsigned PSBT of the new transaction. (only available with 'psbtBumpFee')
+      bumpFeePSBT :: Maybe PartiallySignedTransaction
+    , -- | The id of the new transaction. Only returned when wallet private keys are enabled.
+      bumpFeeTxId :: Maybe TxHash
+    , -- | The fee of the replaced transaction.
+      bumpFeeOrig :: Scientific
+    , -- | The fee of the new transaction.
+      bumpFeeFee :: Scientific
+    , -- | Errors encountered during processing (may be empty).
+      bumpFeeErrors :: [Text]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON BumpFeeResponse where
+    parseJSON = withObject "BumpFeeResponse" $ \obj ->
+        BumpFeeResponse
+            <$> (fmap unBase64Encoded <$> obj .:? "psbt")
+            <*> obj .:? "txid"
+            <*> obj .: "origfee"
+            <*> obj .: "fee"
+            <*> obj .: "errors"
+
+{- | Bumps the fee of an opt-in-RBF transaction T, replacing it with a new
+ transaction B.  An opt-in RBF transaction with the given txid must be in the
+ wallet.  The command will pay the additional fee by reducing change outputs or
+ adding inputs when necessary.  It may add a new change output if one does not
+ already exist.  All inputs in the original transaction will be included in the
+ replacement transaction.  The command will fail if the wallet or mempool
+ contains a transaction that spends one of T's outputs.  By default, the new fee
+ will be calculated automatically using the estimatesmartfee RPC.  The user can
+ specify a confirmation target for estimatesmartfee.  Alternatively, the user
+ can specify a fee rate in sat/vB for the new transaction.  At a minimum, the
+ new fee rate must be high enough to pay an additional new relay fee
+ (incrementalfee returned by getnetworkinfo) to enter the node's mempool.
+
+ Bitcoind >= 0.21
+
+ @since 0.3.0.0
+-}
+bumpFee ::
+    TxHash ->
+    Maybe BumpFeeOptions ->
+    BitcoindClient BumpFeeResponse
+
+data LoadWalletResponse = LoadWalletResponse
+    { -- | The wallet name if created successfully. If the wallet was created
+      -- using a full path, the wallet_name will be the full path.
+      loadWalletName :: Text
+    , -- | Warning message if wallet was not loaded cleanly.
+      loadWalletWarning :: Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON LoadWalletResponse where
+    parseJSON = withObject "LoadWalletResponse" $ \obj ->
+        LoadWalletResponse
+            <$> obj .: "name"
+            <*> obj .: "warning"
+
+-- | Creates and loads a new wallet.
+createWallet ::
+    -- | The name for the new wallet. If this is a path, the wallet will be
+    -- created at the path location.
+    Text ->
+    -- | Disable the possibility of private keys (only watchonlys are possible
+    -- in this mode).  (Default: False)
+    Maybe Bool ->
+    -- | Create a blank wallet. A blank wallet has no keys or HD seed. One can
+    -- be set using sethdseed.  (Default: False)
+    Maybe Bool ->
+    -- | Encrypt the wallet with this passphrase.
+    Text ->
+    -- | Keep track of coin reuse, and treat dirty and clean coins differently
+    -- with privacy considerations in mind.  (Default: False)
+    Maybe Bool ->
+    -- | Create a native descriptor wallet. The wallet will use descriptors
+    -- internally to handle address creation.  (Default: False)
+    Maybe Bool ->
+    -- | Save wallet name to persistent settings and load on startup. True to
+    -- add wallet to startup list, false to remove, null to leave unchanged.
+    Maybe Bool ->
+    -- | Use an external signer such as a hardware wallet. Requires -signer to
+    -- be configured. Wallet creation will fail if keys cannot be fetched. Requires
+    -- disable_private_keys and descriptors set to true.  (Default: False)
+    Maybe Bool ->
+    BitcoindClient LoadWalletResponse
+
+{- | Reveals the private key corresponding to 'address'.  Then the importprivkey
+ can be used with this output
+
+ @since 0.3.0.0
+-}
+dumpPrivKey ::
+    -- | The bitcoin address for the private key
+    Text ->
+    -- | The private key
+    BitcoindClient Text
+
+newtype DumpWalletResponse = DumpWalletResponse {dumpWalletFileName :: FilePath}
+    deriving (Eq, Show)
+
+instance FromJSON DumpWalletResponse where
+    parseJSON = withObject "DumpWalletResponse" $ fmap DumpWalletResponse . (.: "filename")
+
+dumpWallet_ :: FilePath -> BitcoindClient DumpWalletResponse
+
+{- | Dumps all wallet keys in a human-readable format to a server-side file.
+ This does not allow overwriting existing files.  Imported scripts are included
+ in the dumpfile, but corresponding BIP173 addresses, etc. may not be added
+ automatically by importwallet.  Note that if your wallet contains keys which
+ are not derived from your HD seed (e.g. imported keys), these are not covered
+ by only backing up the seed itself, and must be backed up too (e.g. ensure you
+ back up the whole dumpfile).
+
+ @since 0.3.0.0
+-}
+dumpWallet ::
+    -- | The filename with path (absolute path recommended)
+    FilePath ->
+    -- | The filename with full absolute path
+    BitcoindClient FilePath
+dumpWallet = fmap dumpWalletFileName . dumpWallet_
+
+{- | Encrypts the wallet with 'passphrase'. This is for first time encryption.
+ After this, any calls that interact with private keys such as sending or signing
+ will require the passphrase to be set prior the making these calls.
+ Use the walletpassphrase call for this, and then walletlock call.
+ If the wallet is already encrypted, use the walletpassphrasechange call.
+
+ @since 0.3.0.0
+-}
+encryptWallet ::
+    -- | The pass phrase to encrypt the wallet with. It must be at least 1
+    -- character, but should be long.
+    Text ->
+    -- | A string with further instructions
+    BitcoindClient Text
+
+data Purpose = PurposeSend | PurposeRecv
+    deriving (Eq, Show)
+
+instance FromJSON Purpose where
+    parseJSON = withObject "Purpose" $ \obj ->
+        obj .: "purpose" >>= \case
+            "send" -> pure PurposeSend
+            "receive" -> pure PurposeRecv
+            other -> fail $ "Unknown purpose: " <> other
+
+purposeText :: Purpose -> Text
+purposeText = \case
+    PurposeSend -> "send"
+    PurposeRecv -> "receive"
+
+{- | Returns the list of addresses assigned the specified label.
+
+ @since 0.3.0.0
+-}
+getAddressesByLabel ::
+    -- | The label.
+    Text ->
+    -- | Keys: addresses, values: purpose of address ("send" for sending
+    -- address, "receive" for receiving address)
+    BitcoindClient (Map Text Purpose)
+
+-- | @since 0.3.0.0
+data AddressInfo = AddressInfo
+    { -- | The bitcoin address validated.
+      addressInfoAddress :: Text
+    , -- | The hex-encoded scriptPubKey generated by the address.
+      addressInfoScriptPubKey :: Text
+    , -- | If the address is yours.
+      addressInfoIsMine :: Bool
+    , -- | If the address is watchonly.
+      addressInfoWatchOnly :: Bool
+    , -- | If we know how to spend coins sent to this address, ignoring the
+      -- possible lack of private keys.
+      addressInfoSolvable :: Bool
+    , -- | A descriptor for spending coins sent to this address (only when solvable).
+      addressInfoDescriptor :: Maybe Text
+    , -- | The descriptor used to derive this address if this is a descriptor wallet
+      addressInfoParentDesc :: Maybe Text
+    , -- | If the key is a script.
+      addressInfoIsScript :: Bool
+    , -- | If the address was used for change output.
+      addressInfoIsChange :: Bool
+    , -- | If the address is a witness address.
+      addressInfoIsWitness :: Bool
+    , -- | The version number of the witness program.
+      addressInfoWitnessVersion :: Maybe Int
+    , -- | The hex value of the witness program.
+      addressInfoWitnessProgram :: Maybe Text
+    , -- | The output script type. Only if isscript is true and the redeemscript is known. Possible
+      -- types: nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_keyhash,
+      -- witness_v0_scripthash, witness_unknown.
+      addressInfoScriptType :: Maybe Text
+    , -- | The redeemscript for the p2sh address.
+      addressInfoScriptHex :: Maybe Text
+    , -- | Array of pubkeys associated with the known redeemscript (only if script is multisig).
+      addressInfoPubkeys :: [Text]
+    , -- | The number of signatures required to spend multisig output (only if script is multisig).
+      addressInfoSigsRequired :: Maybe Int
+    , -- | The hex value of the raw public key for single-key addresses (possibly embedded in P2SH or P2WSH).
+      addressInfoPubkey :: Maybe Text
+    , -- | Information about the address embedded in P2SH or P2WSH, if relevant and known.
+      -- TODO precise type
+      addressInfoEmbedded :: Maybe Value
+    , -- | If the pubkey is compressed.
+      addressInfoIsCompressed :: Maybe Bool
+    , -- | The creation time of the key, if available, expressed in UNIX epoch time.
+      addressInfoTimestamp :: Maybe UTCTime
+    , -- | The HD keypath, if the key is HD and available.
+      addressInfoHDKeyPath :: Maybe DerivPath
+    , -- | The Hash160 of the HD seed.
+      addressInfoHDSeedId :: Maybe Hash160
+    , -- | The fingerprint of the master key.
+      addressInfoHDMasterFingerprint :: Maybe Text
+    , -- | Array of labels associated with the address. Currently limited to one label but returned
+      -- as an array to keep the API stable if multiple labels are enabled in the future.
+      addressInfoLabels :: [Text]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AddressInfo where
+    parseJSON = withObject "AddressInfo" $ \obj ->
+        AddressInfo
+            <$> obj .: "address"
+            <*> obj .: "scriptPubKey"
+            <*> obj .: "ismine"
+            <*> obj .: "iswatchonly"
+            <*> obj .: "solvable"
+            <*> obj .:? "desc"
+            <*> obj .:? "parent_desc"
+            <*> obj .: "isscript"
+            <*> obj .: "ischange"
+            <*> obj .: "iswitness"
+            <*> obj .:? "witness_version"
+            <*> obj .:? "witness_program"
+            <*> obj .:? "script"
+            <*> obj .:? "hex"
+            <*> (fromMaybe mempty <$> obj .:? "pubkeys")
+            <*> obj .:? "sigsrequired"
+            <*> obj .:? "pubkey"
+            <*> obj .:? "embedded"
+            <*> obj .:? "compressed"
+            <*> (fmap utcTime <$> obj .:? "timestamp")
+            <*> obj .:? "hdkeypath"
+            <*> (fmap unHexEncoded <$> obj .:? "hdseedid")
+            <*> obj .:? "hdmasterfingerprint"
+            <*> obj .: "labels"
+
+{- | Return information about the given bitcoin address.
+ Some of the information will only be present if the address is in the active wallet.
+
+ @since 0.3.0.0
+-}
+getAddressInfo ::
+    -- | The bitcoin address for which to get information.
+    Text ->
+    BitcoindClient AddressInfo
+
+{- | Returns the total available balance.  The available balance is what the
+ wallet considers currently spendable, and is thus affected by options which
+ limit spendability such as -spendzeroconfchange.
+
+ @since 0.3.0.0
+-}
+getBalance ::
+    -- | Only include transactions confirmed at least this many times. (Default: 0)
+    Maybe Int ->
+    -- | Also include balance in watch-only addresses (see 'importaddress')
+    -- (Default: true for watch-only wallets; otherwise false)
+    Maybe Bool ->
+    -- | Do not include balance in dirty outputs; addresses are considered dirty
+    -- if they have previously been used in a transaction.
+    Maybe Bool ->
+    -- | The total amount in sats received for this wallet.
+    BitcoindClient Word64
+getBalance confs watchOnly = fmap toSatoshis . getBalance_ (Just "*") confs watchOnly
+
+getBalance_ ::
+    Maybe Text ->
+    Maybe Int ->
+    Maybe Bool ->
+    Maybe Bool ->
+    BitcoindClient Scientific
+
+-- | @since 0.3.0.0
+data BalanceDetails = BalanceDetails
+    { -- | trusted balance (outputs created by the wallet or confirmed outputs)
+      balanceDetailsTrusted :: Word64
+    , -- | untrusted pending balance (outputs created by others that are in the mempool)
+      balanceDetailsUntrustedPending :: Word64
+    , -- | balance from immature coinbase outputs
+      balanceDetailsImmature :: Word64
+    , -- | (only present if avoid_reuse is set) balance from coins sent to
+      -- addresses that were previously spent from (potentially privacy violating)
+      balanceDetailsUsed :: Maybe Word64
+    }
+    deriving (Eq, Show)
+
+instance FromJSON BalanceDetails where
+    parseJSON = withObject "BalanceDetails" $ \obj ->
+        BalanceDetails
+            <$> (toSatoshis <$> obj .: "trusted")
+            <*> (toSatoshis <$> obj .: "untrusted_pending")
+            <*> (toSatoshis <$> obj .: "immature")
+            <*> (fmap toSatoshis <$> obj .:? "used")
+
+-- | @since 0.3.0.0
+data Balances = Balances
+    { -- | balances from outputs that the wallet can sign
+      balancesMine :: BalanceDetails
+    , -- | watchonly balances (not present if wallet does not watch anything)
+      balancesWatchOnly :: Maybe BalanceDetails
+    }
+    deriving (Eq, Show)
+
+instance FromJSON Balances where
+    parseJSON = withObject "Balances" $ \obj ->
+        Balances
+            <$> obj .: "mine"
+            <*> obj .:? "watchonly"
+
+{- | Returns an object with all balances in sats.
+
+ @since 0.3.0.0
+-}
+getBalances :: BitcoindClient Balances
+
+{- | Returns a new Bitcoin address for receiving payments.
+ If 'label' is specified, it is added to the address book
+ so payments received with the address will be associated with 'label'.
+
+ @since 0.3.0.0
+-}
+getNewAddress ::
+    -- | The label name for the address to be linked to. It can also be set to
+    -- the empty string "" to represent the default label. The label does not need to
+    -- exist, it will be created if there is no label by the given name.
+    Maybe Text ->
+    Maybe AddressType ->
+    -- | The new bitcoin address
+    BitcoindClient Text
+
+{- | Returns a new Bitcoin address, for receiving change.
+ This is for use with raw transactions, NOT normal use.
+
+ @since 0.3.0.0
+-}
+getRawChangeAddress ::
+    Maybe AddressType ->
+    -- | The address
+    BitcoindClient Text
+
+{- | Returns the total amount received by the given address in transactions with
+ at least minconf confirmations.
+
+ @since 0.3.0.0
+-}
+getReceivedByAddress ::
+    -- | The bitcoin address for transactions.
+    Text ->
+    -- | Only include transactions confirmed at least this many times.
+    Maybe Int ->
+    -- | The total amount in sats received at this address.
+    BitcoindClient Word64
+getReceivedByAddress addr = fmap toSatoshis . getReceivedByAddress_ addr
+
+getReceivedByAddress_ :: Text -> Maybe Int -> BitcoindClient Scientific
+
+{- | Returns the total amount received by addresses with <label> in transactions
+ with at least [minconf] confirmations.
+
+ @since 0.3.0.0
+-}
+getReceivedByLabel ::
+    -- | The selected label, may be the default label using "".
+    Text ->
+    -- | Only include transactions confirmed at least this many times.
+    Maybe Int ->
+    -- | The total amount in sats received for this label.
+    BitcoindClient Word64
+getReceivedByLabel label = fmap toSatoshis . getReceivedByLabel_ label
+
+getReceivedByLabel_ :: Text -> Maybe Int -> BitcoindClient Scientific
+
+data Category
+    = Send
+    | Receive
+    | Generate
+    | Immature
+    | Orphan
+    deriving (Eq, Show)
+
+instance FromJSON Category where
+    parseJSON = withText "Category" $ \case
+        "send" -> pure Send
+        "receive" -> pure Receive
+        "generate" -> pure Generate
+        "immature" -> pure Immature
+        "orphan" -> pure Orphan
+        other -> fail $ "Unknown category: " <> Text.unpack other
+
+data GetTxOutputDetails = GetTxOutputDetails
+    { -- | Only returns true if imported addresses were involved in transaction.
+      getTxWatchOnly :: Bool
+    , -- | The bitcoin address involved in the transaction.
+      getTxAddress :: Text
+    , getTxCategory :: Category
+    , -- | The output amount in sats
+      getTxOutputAmount :: Word64
+    , -- | A comment for the address/transaction, if any
+      getTxLabel :: Maybe Text
+    , -- | the vout value
+      getTxVout :: Int
+    , getTxOutputFee :: Maybe Word64
+    , -- | 'true' if the transaction has been abandoned (inputs are respendable). Only
+      -- available for the 'send' category of transactions.
+      getTxAbandoned :: Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON GetTxOutputDetails where
+    parseJSON = withObject "GetTxOutputDetails" $ \obj ->
+        GetTxOutputDetails
+            <$> (fromMaybe False <$> obj .:? "involvesWatchOnly")
+            <*> obj .: "address"
+            <*> obj .: "category"
+            <*> (toSatoshis <$> obj .: "amount")
+            <*> obj .:? "label"
+            <*> obj .: "vout"
+            <*> (fmap (toSatoshis . negate) <$> obj .:? "fee")
+            <*> (fromMaybe False <$> obj .:? "abandoned")
+
+-- | @since 0.3.0.0
+data GetTransactionResponse = GetTransactionResponse
+    { -- | The amount in sats
+      getTxAmount :: Word64
+    , -- | The fee in sats (for "send" transactions)
+      getTxFee :: Maybe Word64
+    , -- | The number of confirmations for the transaction. Negative
+      -- confirmations means the transaction
+      -- conflicted that many blocks ago.
+      getTxConfs :: Int
+    , -- | Only present if transaction only input is a coinbase one.
+      getTxGenerated :: Bool
+    , -- | Only present if we consider transaction to be trusted and so safe to spend from.
+      getTxTrusted :: Bool
+    , -- | The block hash containing the transaction.
+      getTxBlockId :: BlockHash
+    , -- | The block height containing the transaction.
+      getTxBlockHeight :: BlockHeight
+    , -- | The index of the transaction in the block that includes it.
+      getTxBlockIndex :: Int
+    , -- | The block time expressed in UNIX epoch time.
+      getTxBlockTime :: UTCTime
+    , -- | The transaction id.
+      getTxId :: TxHash
+    , -- | Conflicting transaction ids.
+      getTxWalletConflicts :: [Text]
+    , -- | The transaction time expressed in UNIX epoch time.
+      getTxTime :: UTCTime
+    , -- | The time received expressed in UNIX epoch time.
+      getTxTimeReceived :: UTCTime
+    , -- | If a comment is associated with the transaction, only present if not empty.
+      getTxComment :: Maybe Text
+    , getTxReplaceable :: Maybe Bool
+    , getTxDetails :: [GetTxOutputDetails]
+    , getTransactionTx :: Tx
+    }
+    deriving (Eq, Show)
+
+bip125Bool :: Text -> Maybe Bool
+bip125Bool = \case
+    "yes" -> pure True
+    "no" -> pure False
+    _ -> Nothing
+
+instance FromJSON GetTransactionResponse where
+    parseJSON = withObject "GetTransactionResponse" $ \obj ->
+        GetTransactionResponse
+            <$> (toSatoshis <$> obj .: "amount")
+            <*> (fmap (toSatoshis . negate) <$> obj .:? "fee")
+            <*> obj .: "confirmations"
+            <*> (fromMaybe False <$> obj .:? "generated")
+            <*> (fromMaybe False <$> obj .:? "trusted")
+            <*> obj .: "blockhash"
+            <*> obj .: "blockheight"
+            <*> obj .: "blockindex"
+            <*> (utcTime <$> obj .: "blocktime")
+            <*> obj .: "txid"
+            <*> obj .: "walletconflicts"
+            <*> (utcTime <$> obj .: "time")
+            <*> (utcTime <$> obj .: "timereceived")
+            <*> obj .:? "comment"
+            <*> (bip125Bool <$> obj .: "bip125-replaceable")
+            <*> obj .: "details"
+            <*> (unHexEncoded <$> obj .: "hex")
+
+{- | Get detailed information about in-wallet transaction <txid>
+
+ @since 0.3.0.0
+-}
+getTransaction ::
+    -- | The transaction id
+    TxHash ->
+    -- | Whether to include watch-only addresses in balance calculation and details
+    Maybe Bool ->
+    BitcoindClient GetTransactionResponse
+
+-- | @since 0.3.0.0
+data WalletStateInfo = WalletStateInfo
+    { -- | the wallet name
+      walletStateName :: Text
+    , -- | the wallet version
+      walletStateVersion :: Int
+    , -- | the database format (bdb or sqlite)
+      walletStateFormat :: String
+    , -- | the total number of transactions in the wallet
+      walletStateTxCount :: Int
+    , -- | the UNIX epoch time of the oldest pre-generated key in the key pool. Legacy wallets only.
+      walletStateKeyPoolOldest :: UTCTime
+    , -- | how many new keys are pre-generated (only counts external keys)
+      walletStateKeyPoolSize :: Int
+    , -- | how many new keys are pre-generated for internal use (used for change
+      -- outputs, only appears if the wallet is using this feature, otherwise
+      -- external keys are used)
+      walletStateKeyPoolSizeHDInternal :: Maybe Int
+    , -- | the UNIX epoch time until which the wallet is unlocked for transfers, or 0 if the wallet is locked (only present for passphrase-encrypted wallets)
+      walletStateUnlockedUntil :: Maybe UTCTime
+    , -- | the transaction fee configuration, set in sats/kvB
+      walletStatePayTxFee :: Word64
+    , -- | the Hash160 of the HD seed (only present when HD is enabled)
+      walletStateHDSeedId :: Maybe Hash160
+    , -- | false if privatekeys are disabled for this wallet (enforced watch-only wallet)
+      walletStatePrivKeysEnabled :: Bool
+    , -- | whether this wallet tracks clean/dirty coins in terms of reuse
+      walletStateAvoidReuse :: Bool
+    , -- | elapsed seconds since scan start
+      walletStateScanningDuration :: Maybe NominalDiffTime
+    , -- | scanning progress percentage [0.0, 1.0]
+      walletStateScanningProgress :: Maybe Double
+    , -- | whether this wallet uses descriptors for scriptPubKey management
+      walletStateDescriptors :: Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON WalletStateInfo where
+    parseJSON = withObject "WalletStateInfo" $ \obj -> do
+        scanning <- obj .: "scanning"
+        WalletStateInfo
+            <$> obj .: "walletname"
+            <*> obj .: "walletversion"
+            <*> obj .: "format"
+            <*> obj .: "txcount"
+            <*> (utcTime <$> obj .: "keypoololdest")
+            <*> obj .: "keypoolsize"
+            <*> obj .:? "keypoolsize_hd_internal"
+            <*> (fmap utcTime <$> obj .:? "unlocked_until")
+            <*> (toSatoshis <$> obj .: "paytxfee")
+            <*> (fmap unHexEncoded <$> obj .:? "hdseedid")
+            <*> obj .: "private_keys_enabled"
+            <*> obj .: "avoid_reuse"
+            <*> getField "duration" scanning
+            <*> getField "progress" scanning
+            <*> obj .: "descriptors"
+      where
+        getField field (Object obj) = Just <$> obj .: field
+        getField _ _ = pure Nothing
+
+{- | Returns an object containing various wallet state info.
+
+ @since 0.3.0.0
+-}
+getWalletInfo :: BitcoindClient WalletStateInfo
+
+{- | Adds an address or script (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.
+
+ Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls
+ may report that the imported address exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.
+ If you have the full public key, you should call importpubkey instead of this.
+ Hint: use importmulti to import more than one address.
+
+ Note: If you import a non-standard raw script in hex form, outputs sending to it will be treated
+ as change, and not show up in many RPCs.
+ Note: Use "getwalletinfo" to query the scanning progress.
+
+ @since 0.3.0.0
+-}
+importAddress ::
+    -- | The Bitcoin address (or hex-encoded script)
+    Text ->
+    -- | An optional label
+    Maybe Text ->
+    -- | Rescan the wallet for transactions
+    Maybe Bool ->
+    -- | Add the P2SH version of the script as well
+    Maybe Bool ->
+    BitcoindClient ()
+
+-- | @since 0.3.0.0
+data DescriptorRequest = DescriptorRequest
+    { -- | Descriptor to import.
+      descriptorRequestDesc :: Text
+    , -- | Set this descriptor to be the active descriptor for the corresponding output type/externality (Default: false)
+      descriptorRequestActive :: Maybe Bool
+    , -- | If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import
+      descriptorRequestRange :: Maybe (Int, Maybe Int)
+    , -- | If a ranged descriptor is set to active, this specifies the next index to generate addresses from
+      descriptorRequestNextIndex :: Maybe Int
+    , -- | Time from which to start rescanning the blockchain for this descriptor, in UNIX epoch time
+      -- Use the string "now" to substitute the current synced blockchain time.
+      -- "now" can be specified to bypass scanning, for outputs which are known to never have been used, and
+      -- 0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest timestamp
+      -- of all descriptors being imported will be scanned.
+      descriptorRequestTimestamp :: Maybe UTCTime
+    , -- | Whether matching outputs should be treated as not incoming payments (e.g. change) (Default: false)
+      descriptorRequestInternal :: Maybe Bool
+    , -- | Label to assign to the address, only allowed with internal=false (Default: "")
+      descriptorRequestLabel :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance ToJSON DescriptorRequest where
+    toJSON req =
+        partialObject
+            [ Just $ "desc" .= descriptorRequestDesc req
+            , "active" .=? descriptorRequestActive req
+            , "range" .=? (fmap rangeToJSON . descriptorRequestRange) req
+            , "next_index" .=? descriptorRequestNextIndex req
+            , Just $ "timestamp" .= (maybe (toJSON @Text "now") toJSON . descriptorRequestTimestamp) req
+            , "internal" .=? descriptorRequestInternal req
+            , "label" .=? descriptorRequestLabel req
+            ]
+
+-- | @since 0.3.0.0
+data ImportResponse = ImportResponse
+    { importResponseSuccess :: Bool
+    , importResponseWarnings :: [Text]
+    , importResponseError :: Maybe Value
+    }
+    deriving (Eq, Show)
+
+instance FromJSON ImportResponse where
+    parseJSON = withObject "ImportResponse" $ \obj ->
+        ImportResponse
+            <$> obj .: "success"
+            <*> (fromMaybe mempty <$> obj .:? "warnings")
+            <*> obj .:? "error"
+
+{- | Import descriptors. This will trigger a rescan of the blockchain based on
+ the earliest timestamp of all descriptors being imported. Requires a new wallet
+ backup.
+
+  Note: This call can take over an hour to complete if using an early timestamp;
+  during that time, other rpc calls may report that the imported keys, addresses
+  or scripts exist but related transactions are still missing.
+
+  @since 0.3.0.0
+-}
+importDescriptors ::
+    [DescriptorRequest] ->
+    BitcoindClient [ImportResponse]
+
+-- | @since 0.3.0.0
+data ImportScriptPubKey = ImportScript Text | ImportAddress Text
+    deriving (Eq, Show)
+
+instance ToJSON ImportScriptPubKey where
+    toJSON = \case
+        ImportScript script -> toJSON script
+        ImportAddress addr -> object ["address" .= addr]
+
+-- | @since 0.3.0.0
+data ImportMultiRequest = ImportMultiRequest
+    { -- | Descriptor to import. If using descriptor, do not also provide address/scriptPubKey, scripts, or pubkeys
+      importMultiDesc :: Maybe Text
+    , -- | Type of scriptPubKey (string for script, json for address). Should not be provided if using a descriptor
+      importMultiScriptPubKey :: Maybe ImportScriptPubKey
+    , -- | Creation time of the key expressed in UNIX epoch time,
+      -- or the string "now" to substitute the current synced blockchain time. The timestamp of the oldest
+      -- key will determine how far back blockchain rescans need to begin for missing wallet transactions.
+      -- "now" can be specified to bypass scanning, for keys which are known to never have been used, and
+      -- 0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest key
+      -- creation time of all keys being imported by the importmulti call will be scanned.
+      importMultiTimestamp :: Maybe UTCTime
+    , -- | Allowed only if the scriptPubKey is a P2SH or P2SH-P2WSH address/scriptPubKey
+      importMultiRedeemScript :: Maybe Text
+    , -- | Allowed only if the scriptPubKey is a P2SH-P2WSH or P2WSH address/scriptPubKey
+      importMultiWitnessScript :: Maybe Text
+    , -- | Array of strings giving pubkeys to import. They must occur in P2PKH
+      -- or P2WPKH scripts. They are not required when the private key is also
+      -- provided (see the "keys" argument).
+      importMultiPubkeys :: [Text]
+    , -- | Array of strings giving private keys to import. The corresponding
+      -- public keys must occur in the output or redeemscript.
+      importMultiKeys :: [Text]
+    , -- | If a ranged descriptor is used, this specifies the end or the range
+      -- (in the form [begin,end]) to import
+      importMultiRange :: Maybe (Int, Maybe Int)
+    , -- | Stating whether matching outputs should be treated as not incoming
+      -- payments (also known as change)
+      importMultiInternal :: Maybe Bool
+    , -- | Stating whether matching outputs should be considered watchonly.
+      importMultiWatchOnly :: Maybe Bool
+    , -- | Label to assign to the address, only allowed with internal=false
+      importMultiLabel :: Maybe Text
+    , -- | Stating whether imported public keys should be added to the keypool
+      -- for when users request new addresses. Only allowed when wallet private keys
+      -- are disabled
+      importMultiKeypool :: Maybe Bool
+    }
+    deriving (Eq, Show)
+
+instance ToJSON ImportMultiRequest where
+    toJSON req =
+        partialObject
+            [ "desc" .=? importMultiDesc req
+            , "scriptPubKey" .=? importMultiScriptPubKey req
+            , Just $ "timestamp" .= (maybe (toJSON @Text "now") toJSON . importMultiTimestamp) req
+            , "reedemscript" .=? importMultiRedeemScript req
+            , "witnessscript" .=? importMultiWitnessScript req
+            , Just $ "pubkeys" .= importMultiPubkeys req
+            , Just $ "keys" .= importMultiKeys req
+            , "range" .=? (fmap rangeToJSON . importMultiRange) req
+            , "internal" .=? importMultiInternal req
+            , "watchonly" .=? importMultiWatchOnly req
+            , "label" .=? importMultiLabel req
+            , "keypool" .=? importMultiKeypool req
+            ]
+
+newtype ImportMultiOptions = ImportMultiOptions Bool
+    deriving (Eq, Show)
+
+instance ToJSON ImportMultiOptions where
+    toJSON (ImportMultiOptions doRescan) = object ["rescan" .= doRescan]
+
+importMulti_ ::
+    [ImportMultiRequest] ->
+    Maybe ImportMultiOptions ->
+    BitcoindClient [ImportResponse]
+
+{- | Import addresses/scripts (with private or public keys, redeem script
+ (P2SH)), optionally rescanning the blockchain from the earliest creation time
+ of the imported scripts. Requires a new wallet backup.  If an address/script is
+ imported without all of the private keys required to spend from that address,
+ it will be watchonly. The 'watchonly' option must be set to true in this case
+ or a warning will be returned.  Conversely, if all the private keys are
+ provided and the address/script is spendable, the watchonly option must be set
+ to false, or a warning will be returned.
+
+ Note: This call can take over an hour to complete if rescan is true, during
+ that time, other rpc calls may report that the imported keys, addresses or
+ scripts exist but related transactions are still missing. Note: Use
+ "getwalletinfo" to query the scanning progress.
+
+ @since 0.3.0.0
+-}
+importMulti ::
+    [ImportMultiRequest] ->
+    -- | Stating if should rescan the blockchain after all imports
+    Maybe Bool ->
+    BitcoindClient [ImportResponse]
+importMulti req = importMulti_ req . fmap ImportMultiOptions
+
+{- | Adds a private key (as returned by dumpprivkey) to your wallet. Requires a
+ new wallet backup.  Hint: use importmulti to import more than one private key.
+
+ Note: This call can take over an hour to complete if rescan is true, during
+ that time, other rpc calls may report that the imported key exists but related
+ transactions are still missing, leading to temporarily incorrect/bogus balances
+ and unspent outputs until rescan completes. Note: Use "getwalletinfo" to query
+ the scanning progress.
+
+ @since 0.3.0.0
+-}
+importPrivKey ::
+    -- | The private key (see dumpprivkey)
+    Text ->
+    -- | An optional label
+    Maybe Text ->
+    -- | Rescan the wallet for transactions
+    Maybe Bool ->
+    BitcoindClient ()
+
+{- | Imports keys from a wallet dump file (see dumpwallet). Requires a new
+ wallet backup to include imported keys. Note: Use "getwalletinfo" to query the
+ scanning progress.
+
+ @since 0.3.0.0
+-}
+importWallet ::
+    -- | The wallet file
+    FilePath ->
+    BitcoindClient ()
+
+-- | @since 0.3.0.0
+data DescriptorDetails = DescriptorDetails
+    { -- | Descriptor string representation
+      descriptorDesc :: Text
+    , -- | The creation time of the descriptor
+      descriptorTimestamp :: UTCTime
+    , -- | Activeness flag
+      descriptorActive :: Bool
+    , -- | Whether this is internal or external descriptor; defined only for
+      -- active descriptors
+      descriptorInternal :: Bool
+    , -- | Defined only for ranged descriptors
+      descriptorRange :: Maybe (Int, Int)
+    , -- | The next index to generate addresses from; defined only for ranged
+      -- descriptors
+      descriptorNext :: Maybe Int
+    }
+    deriving (Eq, Show)
+
+instance FromJSON DescriptorDetails where
+    parseJSON = withObject "DescriptorDetails" $ \obj ->
+        DescriptorDetails
+            <$> obj .: "desc"
+            <*> (utcTime <$> obj .: "timestamp")
+            <*> obj .: "active"
+            <*> obj .: "internal"
+            <*> (obj .:? "range" >>= rangeFromJSON)
+            <*> obj .: "next"
+      where
+        rangeFromJSON = \case
+            Just [start, end] -> pure $ Just (start, end)
+            Just{} -> fail "Malformed range"
+            Nothing -> pure Nothing
+
+{- | List descriptors imported into a descriptor-enabled wallet.  Supported
+starting in version @0.21.1@.
+
+ @since 0.3.0.0
+-}
+listDescriptors :: BitcoindClient [DescriptorDetails]
+
+{- | Returns the list of all labels, or labels that are assigned to addresses
+ with a specific purpose.
+
+ @since 0.3.0.0
+-}
+listLabels ::
+    -- | Address purpose to list labels for ('send','receive'). An empty string
+    -- is the same as not providing this argument.
+    Maybe Purpose ->
+    BitcoindClient [Text]
+listLabels = listLabels_ . fmap purposeText
+
+listLabels_ :: Maybe Text -> BitcoindClient [Text]
+
+newtype JsonOutPoint = JsonOutPoint {unJsonOutPoint :: OutPoint}
+    deriving (Eq, Show)
+
+instance FromJSON JsonOutPoint where
+    parseJSON = withObject "JsonOutPoint" $ \obj ->
+        fmap JsonOutPoint $ OutPoint <$> obj .: "txid" <*> obj .: "vout"
+
+listLockUnspent_ :: BitcoindClient [JsonOutPoint]
+
+{- | Returns list of temporarily unspendable outputs. See the 'lockUnspent' call
+ to lock and unlock transactions for spending.
+
+ @since 0.3.0.0
+-}
+listLockUnspent :: BitcoindClient [OutPoint]
+listLockUnspent = fmap unJsonOutPoint <$> listLockUnspent_
+
+-- | @since 0.3.0.0
+data ListReceivedResponse = ListReceivedResponse
+    { -- | Only returns true if imported addresses were involved in transaction
+      listReceivedWatchOnly :: Bool
+    , -- | The receiving address
+      listReceivedAddress :: Text
+    , -- | The total amount in sats received by the address
+      listReceivedAmount :: Word64
+    , -- | The number of confirmations of the most recent transaction included
+      listReceivedConfs :: Int
+    , -- | The label of the receiving address. The default label is ""
+      listReceivedLabel :: Text
+    , -- | The ids of transactions received with the address
+      listReceivedTxIds :: [TxHash]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON ListReceivedResponse where
+    parseJSON = withObject "ListReceivedResponse" $ \obj ->
+        ListReceivedResponse
+            <$> (fromMaybe False <$> obj .:? "involvesWatchOnly")
+            <*> obj .: "address"
+            <*> (toSatoshis <$> obj .: "amount")
+            <*> obj .: "confirmations"
+            <*> obj .: "label"
+            <*> obj .: "txids"
+
+{- | List balances by receiving address.
+
+ @since 0.3.0.0
+-}
+listReceivedByAddress ::
+    -- | The minimum number of confirmations before payments are included.
+    Maybe Int ->
+    -- | Whether to include addresses that haven't received any payments.
+    Maybe Bool ->
+    -- | Whether to include watch-only addresses (see 'importaddress')
+    Maybe Bool ->
+    -- | If present, only return information on this address.
+    Maybe Text ->
+    BitcoindClient [ListReceivedResponse]
+
+-- | @since 0.3.0.0
+data ListReceivedByLabelResponse = ListReceivedByLabelResponse
+    { -- | Only returns true if imported addresses were involved in transaction
+      listRecvByLabelWatchOnly :: Bool
+    , -- | The total amount received by addresses with this label
+      listRecvByLabelAmount :: Word64
+    , -- | The number of confirmations of the most recent transaction included
+      listRecvByLabelConfs :: Int
+    , -- | The label of the receiving address. The default label is ""
+      listRecvByLabelLabel :: Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON ListReceivedByLabelResponse where
+    parseJSON = withObject "ListReceivedByLabelResponse" $ \obj ->
+        ListReceivedByLabelResponse
+            <$> (fromMaybe False <$> obj .:? "involvesWatchOnly")
+            <*> obj .: "amount"
+            <*> obj .: "confirmations"
+            <*> obj .: "label"
+
+-- | List received transactions by label.
+listReceivedByLabel ::
+    -- | The minimum number of confirmations before payments are included.
+    Maybe Int ->
+    -- | Whether to include labels that haven't received any payments.
+    Maybe Bool ->
+    -- | Whether to include watch-only addresses (see 'importAddress')
+    Maybe Bool ->
+    BitcoindClient [ListReceivedByLabelResponse]
+
+-- | @since 0.3.0.0
+data TransactionDetails = TransactionDetails
+    { -- | Only returns true if imported addresses were involved in transaction.
+      txDetailsWatchOnly :: Bool
+    , -- | The bitcoin address involved in the transaction.
+      txDetailsAddress :: Text
+    , -- | The transaction category.
+      txDetailsCategory :: Category
+    , -- | The amount in sats
+      txDetailsAmount :: Word64
+    , -- | A comment for the address/transaction, if any
+      txDetailsLabel :: Maybe Text
+    , -- | The vout value
+      txDetailsVout :: Int
+    , -- | The amount of the fee in sats. This is only available for
+      -- the 'send' category of transactions.
+      txDetailsFee :: Maybe Word64
+    , -- | 'true' if the transaction has been abandoned (inputs are
+      -- respendable). Only available for the 'send' category of transactions.
+      txDetailsAbandoned :: Maybe Bool
+    , -- | The number of confirmations for the transaction. Negative confirmations means the transaction conflicted that many blocks ago.
+      txDetailsConfs :: Int
+    , -- | Only present if transaction only input is a coinbase one.
+      txDetailsGenerated :: Bool
+    , -- | Only present if we consider transaction to be trusted and so safe to spend from.
+      txDetailsTrusted :: Bool
+    , -- | The block hash containing the transaction.
+      txDetailsBlockHash :: BlockHash
+    , -- | The block height containing the transaction.
+      txDetailsBlockHeight :: BlockHeight
+    , -- | The index of the transaction in the block that includes it.
+      txDetailsBlockIndex :: Int
+    , -- | The block time expressed in UNIX epoch time.
+      txDetailsBlockTime :: UTCTime
+    , -- | The transaction id.
+      txDetailsTxId :: TxHash
+    , -- | Conflicting transaction ids.
+      txDetailsConflicts :: [TxHash]
+    , -- | The transaction time
+      txDetailsTime :: UTCTime
+    , -- | The time received
+      txDetailsReceivedTime :: UTCTime
+    , -- | Whether this transaction could be replaced due to BIP125
+      -- (replace-by-fee); may be unknown for unconfirmed transactions not in the
+      -- mempool
+      txDetailsReplaceable :: Maybe Bool
+    , -- | If a comment to is associated with the transaction.
+      txDetailsTo :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON TransactionDetails where
+    parseJSON = withObject "TransactionDetails" $ \obj ->
+        TransactionDetails
+            <$> (fromMaybe False <$> obj .:? "involvesWatchOnly")
+            <*> obj .: "address"
+            <*> obj .: "category"
+            <*> (toSatoshis <$> obj .: "amount")
+            <*> obj .:? "label"
+            <*> obj .: "vout"
+            <*> (fmap (toSatoshis . negate) <$> obj .:? "fee")
+            <*> obj .:? "abandoned"
+            <*> obj .: "confirmations"
+            <*> (fromMaybe False <$> obj .:? "generated")
+            <*> (fromMaybe False <$> obj .:? "trusted")
+            <*> obj .: "blockhash"
+            <*> obj .: "blockheight"
+            <*> obj .: "blockindex"
+            <*> (utcTime <$> obj .: "blocktime")
+            <*> obj .: "txid"
+            <*> obj .: "walletconflicts"
+            <*> (utcTime <$> obj .: "time")
+            <*> (utcTime <$> obj .: "timereceived")
+            <*> ((>>= bip125Bool) <$> obj .:? "bip125-replaceable")
+            <*> obj .:? "to"
+
+-- | @since 0.3.0.0
+data ListSinceBlockResponse = ListSinceBlockResponse
+    { listSinceBlockTxs :: [TransactionDetails]
+    , listSinceBlockRemoved :: [TransactionDetails]
+    , listSinceBlockLastBlock :: BlockHash
+    }
+    deriving (Eq, Show)
+
+instance FromJSON ListSinceBlockResponse where
+    parseJSON = withObject "ListSinceBlockResponse" $ \obj ->
+        ListSinceBlockResponse
+            <$> obj .: "transactions"
+            <*> (fromMaybe mempty <$> obj .: "removed")
+            <*> obj .: "lastblock"
+
+{- | Get all transactions in blocks since block [blockhash], or all transactions
+ if omitted.  If "blockhash" is no longer a part of the main chain,
+ transactions from the fork point onward are included.  Additionally, if
+ include_removed is set, transactions affecting the wallet which were removed
+ are returned in the "removed" array.
+
+ @since 0.3.0.0
+-}
+listSinceBlock ::
+    -- | If set, the block hash to list transactions since, otherwise list all
+    -- transactions.
+    Maybe BlockHash ->
+    -- | Return the nth block hash from the main chain. e.g. 1 would mean the
+    -- best block hash. Note: this is not used as a filter, but only affects
+    -- [lastblock] in the return value
+    Maybe Int ->
+    -- | Include transactions to watch-only addresses (see 'importaddress')
+    Maybe Bool ->
+    -- | Show transactions that were removed due to a reorg in the "removed" array
+    -- (not guaranteed to work on pruned nodes)
+    Maybe Bool ->
+    BitcoindClient ListSinceBlockResponse
+
+{- | If a label name is provided, this will return only incoming transactions
+ paying to addresses with the specified label. Returns up to 'count' most
+ recent transactions skipping the first 'from' transactions.
+
+ @since 0.3.0.0
+-}
+listTransactions ::
+    -- | If set, should be a valid label name to return only incoming
+    -- transactions with the specified label, or "*" to disable filtering and
+    -- return all transactions.
+    Maybe Text ->
+    -- | The number of transactions to return (default: 10)
+    Maybe Int ->
+    -- | The number of transactions to skip
+    Maybe Int ->
+    -- | Include transactions to watch-only addresses (see 'importAddress')
+    Maybe Bool ->
+    BitcoindClient [TransactionDetails]
+
+-- | @since 0.3.0.0
+data ListUnspentOptions = ListUnspentOptions
+    { -- | Minimum value of each UTXO in sats
+      listUnspentMinAmount :: Maybe Word64
+    , -- | Maximum value of each UTXO in sats
+      listUnspentMaxAmount :: Maybe Word64
+    , -- | Maximum number of UTXOs
+      listUnspentMaxCount :: Maybe Int
+    , -- | Minimum sum value of all UTXOs in sats
+      listUnspentMinSumAmount :: Maybe Word64
+    }
+    deriving (Eq, Show)
+
+instance ToJSON ListUnspentOptions where
+    toJSON opts =
+        partialObject
+            [ "minimumAmount" .=? (satsToBTCText <$> listUnspentMinAmount opts)
+            , "maximumAmount" .=? (satsToBTCText <$> listUnspentMaxAmount opts)
+            , "maximumCount" .=? listUnspentMaxCount opts
+            , "minimumSumAmount" .=? (satsToBTCText <$> listUnspentMinSumAmount opts)
+            ]
+
+-- | @since 0.3.0.0
+data OutputDetails = OutputDetails
+    { -- | the transaction id
+      outputTxId :: TxHash
+    , -- | the vout value
+      outputVOut :: Int
+    , -- | the bitcoin address
+      outputAddress :: Text
+    , -- | The associated label, or "" for the default label
+      outputLabel :: Maybe Text
+    , -- | the script key
+      outputScriptPubKey :: Text
+    , -- | the transaction output amount in sats
+      outputAmount :: Word64
+    , -- | The number of confirmations
+      outputConfs :: Int
+    , -- | The redeemScript if scriptPubKey is P2SH
+      outputRedeemScript :: Maybe Text
+    , -- | witnessScript if the scriptPubKey is P2WSH or P2SH-P2WSH
+      outputWitnessScript :: Maybe Text
+    , -- | Whether we have the private keys to spend this output
+      outputSpendable :: Bool
+    , -- | Whether we know how to spend this output, ignoring the lack of keys
+      outputSolvable :: Bool
+    , -- | Whether this output is reused/dirty (sent to an address that was previously spent from)
+      outputReused :: Maybe Bool
+    , -- | A descriptor for spending this output
+      outputDescriptor :: Maybe Text
+    , -- | Whether this output is considered safe to spend. Unconfirmed transactions
+      -- from outside keys and unconfirmed replacement transactions are considered unsafe
+      -- and are not eligible for spending by fundrawtransaction and sendtoaddress.
+      outputSafe :: Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON OutputDetails where
+    parseJSON = withObject "OutputDetails" $ \obj ->
+        OutputDetails
+            <$> obj .: "txid"
+            <*> obj .: "vout"
+            <*> obj .: "address"
+            <*> obj .:? "label"
+            <*> obj .: "scriptPubKey"
+            <*> (toSatoshis <$> obj .: "amount")
+            <*> obj .: "confirmations"
+            <*> obj .:? "redeemScript"
+            <*> obj .:? "witnessScript"
+            <*> obj .: "spendable"
+            <*> obj .: "solvable"
+            <*> obj .:? "reused"
+            <*> obj .:? "desc"
+            <*> obj .: "safe"
+
+{- | Returns array of unspent transaction outputs with between minconf and maxconf
+ (inclusive) confirmations.  Optionally filter to only include txouts paid to
+ specified addresses.
+
+ @since 0.3.0.0
+-}
+listUnspent ::
+    -- | The minimum confirmations to filter
+    Maybe Int ->
+    -- | The maximum confirmations to filter
+    Maybe Int ->
+    -- | The bitcoin addresses to filter
+    Maybe [Text] ->
+    -- | Include outputs that are not safe to spend
+    Maybe Bool ->
+    ListUnspentOptions ->
+    BitcoindClient [OutputDetails]
+
+{- | Returns a list of currently loaded wallets.
+ For full information on the wallet, use 'getWalletInfo'
+
+ @since 0.3.0.0
+-}
+listWallets :: BitcoindClient [Text]
+
+{- | Loads a wallet from a wallet file or directory.  Note that all wallet
+ command-line options used when starting bitcoind will be applied to the new
+ wallet (eg -rescan, etc).
+
+ @since 0.3.0.0
+-}
+loadWallet ::
+    -- | The wallet directory or .dat file.
+    Text ->
+    -- | Save wallet name to persistent settings and load on startup. True to
+    -- add wallet to startup list, false to remove, null to leave unchanged.
+    Maybe Bool ->
+    BitcoindClient LoadWalletResponse
+
+{- | Updates list of temporarily unspendable outputs.  Temporarily lock
+ (unlock=false) or unlock (unlock=true) specified transaction outputs.  If no
+ transaction outputs are specified when unlocking then all current locked
+ transaction outputs are unlocked.  A locked transaction output will not be
+ chosen by automatic coin selection, when spending bitcoins.  Manually selected
+ coins are automatically unlocked.  Locks are stored in memory only. Nodes start
+ with zero locked outputs, and the locked output list is always cleared (by
+ virtue of process exit) when a node stops or fails.  Also see the listunspent
+ call
+
+ @since 0.3.0.0
+-}
+lockUnspent ::
+    -- | Whether to unlock (true) or lock (false) the specified transactions
+    Bool ->
+    -- | The transaction outputs and within each, the txid (string) vout (numeric).
+    [PrevTx] ->
+    BitcoindClient Bool
+
+{- | Bumps the fee of an opt-in-RBF transaction T, replacing it with a new
+ transaction B.  Returns a PSBT instead of creating and signing a new
+ transaction.  An opt-in RBF transaction with the given txid must be in the
+ wallet.  The command will pay the additional fee by reducing change outputs or
+ adding inputs when necessary.  It may add a new change output if one does not
+ already exist.  All inputs in the original transaction will be included in the
+ replacement transaction.  The command will fail if the wallet or mempool
+ contains a transaction that spends one of T's outputs.  By default, the new fee
+ will be calculated automatically using the estimatesmartfee RPC.  The user can
+ specify a confirmation target for estimatesmartfee.  Alternatively, the user
+ can specify a fee rate in sat/vB for the new transaction.  At a minimum, the
+ new fee rate must be high enough to pay an additional new relay fee
+ (incrementalfee returned by getnetworkinfo) to enter the node's mempool.  *
+ WARNING: before version 0.21, fee_rate was in BTC/kvB. As of 0.21, fee_rate is
+ in sat/vB. *
+
+ @since 0.3.0.0
+-}
+psbtBumpFee ::
+    -- | The txid to be bumped
+    TxHash ->
+    Maybe BumpFeeOptions ->
+    BitcoindClient BumpFeeResponse
+
+-- | @since 0.3.0.0
+data RescanResponse = RescanResponse
+    { -- | The block height where the rescan started (the requested height or 0)
+      rescanStart :: Int
+    , -- | The height of the last rescanned block. May be null in rare cases if
+      -- there was a reorg and the call didn't scan any blocks because they were
+      -- already scanned in the background.
+      rescanStop :: Maybe Int
+    }
+    deriving (Eq, Show)
+
+instance FromJSON RescanResponse where
+    parseJSON = withObject "RescanResponse" $ \obj ->
+        RescanResponse
+            <$> obj .: "start_height"
+            <*> obj .:? "stop_height"
+
+{- | Rescan the local blockchain for wallet related transactions.
+ Note: Use 'getWalletInfo' to query the scanning progress.
+
+ @since 0.3.0.0
+-}
+rescanBlockchain ::
+    Maybe BlockHeight ->
+    Maybe BlockHeight ->
+    BitcoindClient RescanResponse
+
+-- | @since 0.3.0.0
+data FeeEstimationMode
+    = Conservative
+    | Economical
+    | Unset
+    deriving (Eq, Show)
+
+instance FromJSON FeeEstimationMode where
+    parseJSON = withText "FeeEstimationMode" $ \case
+        "conservative" -> pure Conservative
+        "economical" -> pure Economical
+        "unset" -> pure Unset
+        other -> fail $ "Unknown fee estimation mode: " <> Text.unpack other
+
+instance ToJSON FeeEstimationMode where
+    toJSON = \case
+        Conservative -> "conservative"
+        Economical -> "economical"
+        Unset -> "unset"
+
+{- | Send multiple times. Amounts are double-precision floating point numbers.
+ Requires wallet passphrase to be set with walletpassphrase call if wallet is
+ encrypted.
+
+ @since 0.3.0.0
+-}
+sendMany ::
+    -- | The bitcoin address is the key, the amount in sats is the value
+    Map Text Word64 ->
+    -- | A comment
+    Maybe Text ->
+    -- | The addresses.
+    -- The fee will be equally deducted from the amount of each selected address.
+    -- Those recipients will receive less bitcoins than you enter in their corresponding amount field.
+    -- If no addresses are specified here, the sender pays the fee.
+    [Text] ->
+    -- | Allow this transaction to be replaced by a transaction with higher fees via BIP 125
+    Maybe Bool ->
+    -- | Confirmation target in blocks
+    Maybe Int ->
+    Maybe FeeEstimationMode ->
+    -- | Specify a fee rate in sat/vB.
+    Maybe Word64 ->
+    BitcoindClient TxHash
+sendMany = sendMany_ . fmap satsToBTCText
+
+sendMany_ ::
+    Map Text Text ->
+    Maybe Text ->
+    [Text] ->
+    Maybe Bool ->
+    Maybe Int ->
+    Maybe FeeEstimationMode ->
+    Maybe Word64 ->
+    BitcoindClient TxHash
+
+{- | Send an amount to a given address.  Requires wallet passphrase to be set
+ with walletpassphrase call if wallet is encrypted.
+
+ @since 0.3.0.0
+-}
+sendToAddress ::
+    -- | The bitcoin address to send to.
+    Text ->
+    -- | The amount in sats to send
+    Word64 ->
+    -- | A comment used to store what the transaction is for. This is not part
+    -- of the transaction, just kept in your wallet.
+    Maybe Text ->
+    -- | A comment to store the name of the person or organization
+    -- to which you're sending the transaction. This is not part of the
+    -- transaction, just kept in your wallet.
+    Maybe Text ->
+    -- | The fee will be deducted from the amount being sent.
+    -- The recipient will receive less bitcoins than you enter in the amount field.
+    Maybe Bool ->
+    -- | Allow this transaction to be replaced by a transaction with higher fees via BIP 125
+    Maybe Bool ->
+    -- | Confirmation target in blocks
+    Maybe Int ->
+    Maybe FeeEstimationMode ->
+    -- | Avoid spending from dirty addresses; addresses are considered dirty if
+    -- they have previously been used in a transaction.
+    Maybe Bool ->
+    -- | Specify a fee rate in sat/vB.
+    Maybe Word64 ->
+    BitcoindClient TxHash
+sendToAddress addr = sendToAddress_ addr . satsToBTCText
+
+sendToAddress_ ::
+    Text ->
+    Text ->
+    Maybe Text ->
+    Maybe Text ->
+    Maybe Bool ->
+    Maybe Bool ->
+    Maybe Int ->
+    Maybe FeeEstimationMode ->
+    Maybe Bool ->
+    Maybe Word64 ->
+    BitcoindClient TxHash
+
+-- | Sets the label associated with the given address.
+setLabel ::
+    -- | The bitcoin address to be associated with a label.
+    Text ->
+    -- | The label to assign to the address.
+    Text ->
+    BitcoindClient ()
+
+{- | Set the transaction fee per kB for this wallet. Overrides the global
+ -paytxfee command line parameter.  Can be deactivated by passing 0 as the fee.
+ In that case automatic fee selection will be used by default.
+
+ @since 0.3.0.0
+-}
+setTxFee ::
+    -- | The transaction fee in sats/kvB
+    Word64 ->
+    -- | Returns true if successful
+    BitcoindClient Bool
+setTxFee = setTxFee_ . satsToBTCText
+
+setTxFee_ :: Text -> BitcoindClient Bool
+
+{- | Sign a message with the private key of an address
+ Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+
+ @since 0.3.0.0
+-}
+signMessage ::
+    -- | The bitcoin address to use for the private key.
+    Text ->
+    -- | The message to create a signature of.
+    Text ->
+    -- | The signature of the message encoded in base 64
+    BitcoindClient Text
+
+data PrevTx = PrevTx
+    { -- | The transaction id
+      prevTxId :: TxHash
+    , -- | The output number
+      prevTxVOut :: Int
+    , -- | script key
+      prevTxScriptPubKey :: Text
+    , -- | redeem script (required for P2SH)
+      prevTxRedeemScript :: Maybe Text
+    , -- | witness script (required for P2WSH or P2SH-P2WSH)
+      prevTxWitnessScript :: Maybe Text
+    , -- | the amount spent (required for segwit inputs)
+      prevTxAmount :: Word64
+    }
+    deriving (Eq, Show)
+
+instance ToJSON PrevTx where
+    toJSON tx =
+        partialObject
+            [ Just $ "txid" .= prevTxId tx
+            , Just $ "vout" .= prevTxVOut tx
+            , Just $ "scriptPubKey" .= prevTxScriptPubKey tx
+            , "reedemScript" .=? prevTxRedeemScript tx
+            , "witnessScript" .=? prevTxWitnessScript tx
+            , Just $ "amount" .= prevTxAmount tx
+            ]
+
+data SignRawTxError = SignRawTxError
+    { signRawTxErrorTxId :: TxHash
+    , signRawTxErrorVOut :: Int
+    , signRawTxErrorScriptSig :: Text
+    , signRawTxErrorSequence :: Int
+    , signRawTxError :: Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON SignRawTxError where
+    parseJSON = withObject "SignRawTxError" $ \obj ->
+        SignRawTxError
+            <$> obj .: "txid"
+            <*> obj .: "vout"
+            <*> obj .: "scriptSig"
+            <*> obj .: "sequence"
+            <*> obj .: "error"
+
+data SignRawTxResponse = SignRawTxResponse
+    { signRawTxHex :: Text
+    , signRawTxComplete :: Bool
+    , signRawTxErrors :: [SignRawTxError]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON SignRawTxResponse where
+    parseJSON = withObject "SignRawTxResponse" $ \obj ->
+        SignRawTxResponse
+            <$> obj .: "hex"
+            <*> obj .: "complete"
+            <*> obj .: "errors"
+
+{- | Sign inputs for raw transaction (serialized, hex-encoded).  The second
+ optional argument (may be null) is an array of previous transaction outputs
+ that this transaction depends on but may not yet be in the block chain.
+ Requires wallet passphrase to be set with walletpassphrase call if wallet is
+ encrypted.
+
+ @since 0.3.0.0
+-}
+signRawTx ::
+    -- | The transaction hex string
+    Text ->
+    -- | The previous dependent transaction outputs
+    [PrevTx] ->
+    -- | The signature hash type. Must be one of "ALL" "NONE" "SINGLE"
+    -- "ALL|ANYONECANPAY" "NONE|ANYONECANPAY" "SINGLE|ANYONECANPAY"
+    Maybe Text ->
+    BitcoindClient SignRawTxResponse
+
+newtype UnloadWalletResponse = UnloadWalletResponse {unUnloadWalletResponse :: Text}
+    deriving (Eq, Show)
+
+instance FromJSON UnloadWalletResponse where
+    parseJSON = withObject "UnloadWalletResponse" $ fmap UnloadWalletResponse . (.: "warning")
+
+unloadWallet_ ::
+    Maybe Text ->
+    Maybe Bool ->
+    BitcoindClient UnloadWalletResponse
+
+{- | Unloads the wallet referenced by the request endpoint otherwise unloads the
+wallet specified in the argument.  Specifying the wallet name on a wallet
+endpoint is invalid.
+
+ @since 0.3.0.0
+-}
+unloadWallet ::
+    -- | The name of the wallet to unload. If provided both here and in the RPC
+    -- endpoint, the two must be identical.
+    Maybe Text ->
+    -- | Save wallet name to persistent settings and load on startup. True to
+    -- add wallet to startup list, false to remove, null to leave unchanged.
+    Maybe Bool ->
+    BitcoindClient Text
+unloadWallet name = fmap unUnloadWalletResponse . unloadWallet_ name
+
+-- | @since 0.3.0.0
+data CreatePsbtOptions = CreatePsbtOptions
+    { -- | If inputs are specified, automatically include more if they are not enough.
+      createPsbtAddInputs :: Maybe Bool
+    , -- | The bitcoin address to receive the change
+      createPsbtChangeAddress :: Maybe Text
+    , -- | The index of the change output
+      createPsbtChangePosition :: Maybe Int
+    , -- | The output type to use. Only valid if changeAddress is not specified.
+      createPsbtChangeType :: Maybe AddressType
+    , -- | Also select inputs which are watch only
+      createPsbtIncludeWatching :: Maybe Bool
+    , -- | Lock selected unspent outputs
+      createPsbtLockUnspents :: Maybe Bool
+    , -- | Specify a fee rate in sat/vB.
+      createPsbtFeeRate :: Maybe Word64
+    , -- | The outputs to subtract the fee from. The fee will be equally
+      -- deducted from the amount of each specified output. Those recipients will
+      -- receive less bitcoins than you enter in their corresponding amount field. If
+      -- no outputs are specified here, the sender pays the fee.
+      --
+      -- (zero-based output index, before a change output is added)
+      createPsbtSubtractFee :: [Int]
+    , -- | Marks this transaction as BIP125 replaceable. Allows this transaction
+      -- to be replaced by a transaction with higher fees
+      createPsbtReplaceable :: Maybe Bool
+    , -- | Confirmation target in blocks
+      createPsbtConfTarget :: Maybe Int
+    , createPsbtEstimateMode :: Maybe FeeEstimationMode
+    }
+    deriving (Eq, Show)
+
+instance ToJSON CreatePsbtOptions where
+    toJSON opts =
+        partialObject
+            [ "add_inputs" .=? createPsbtAddInputs opts
+            , "changeAddress" .=? createPsbtChangeAddress opts
+            , "changePosition" .=? createPsbtChangePosition opts
+            , "change_type" .=? createPsbtChangeType opts
+            , "includeWatching" .=? createPsbtIncludeWatching opts
+            , "lockUnspents" .=? createPsbtLockUnspents opts
+            , "fee_rate" .=? createPsbtFeeRate opts
+            , Just $ "subtractFeeFromOutputs" .= createPsbtSubtractFee opts
+            , "replaceable" .=? createPsbtReplaceable opts
+            , "conf_target" .=? createPsbtConfTarget opts
+            , "estimate_mode" .=? createPsbtEstimateMode opts
+            ]
+
+-- | @since 0.3.0.0
+data CreatePsbtResponse = CreatePsbtResponse
+    { -- | The resulting raw transaction (base64-encoded string)
+      createPsbtPsbt :: Text
+    , -- | Fee in sats the resulting transaction pays
+      createPsbtFee :: Word64
+    , -- | The position of the added change output, or -1
+      createPsbtChangePos :: Int
+    }
+    deriving (Eq, Show)
+
+instance FromJSON CreatePsbtResponse where
+    parseJSON = withObject "CreatePsbtResponse" $ \obj ->
+        CreatePsbtResponse
+            <$> obj .: "psbt"
+            <*> (toSatoshis <$> obj .: "fee")
+            <*> obj .: "changepos"
+
+{- |
+ Creates and funds a transaction in the Partially Signed Transaction format.
+ Implements the Creator and Updater roles.
+
+ @since 0.3.0.0
+-}
+createFundedPsbt ::
+    -- | Leave empty to add inputs automatically. See add_inputs option.
+    [PsbtInput] ->
+    -- | The outputs (key-value pairs), where none of the keys are duplicated.
+    -- That is, each address can only appear once and there can only be one 'data' object.
+    -- For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also
+    -- accepted as second parameter.
+    PsbtOutputs ->
+    -- | Raw locktime. Non-0 value also locktime-activates inputs
+    Maybe Int ->
+    Maybe CreatePsbtOptions ->
+    -- | Include BIP 32 derivation paths for public keys if we know them
+    Maybe Bool ->
+    BitcoindClient CreatePsbtResponse
+
+-- | @since 0.3.0.0
+data ProcessPsbtResponse = ProcessPsbtResponse
+    { -- | The base64-encoded partially signed transaction
+      processPsbtPsbt :: Text
+    , -- | If the transaction has a complete set of signatures
+      processPsbtComplete :: Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON ProcessPsbtResponse where
+    parseJSON = withObject "ProcessPsbtResponse" $ \obj ->
+        ProcessPsbtResponse <$> obj .: "psbt" <*> obj .: "complete"
+
+{- | Removes the wallet encryption key from memory, locking the wallet.  After
+ calling this method, you will need to call walletpassphrase again before being
+ able to call any methods which require the wallet to be unlocked.
+
+ @since 0.3.0.0
+-}
+walletLock :: BitcoindClient ()
+
+{- | Stores the wallet decryption key in memory for 'timeout' seconds.  This is
+ needed prior to performing transactions related to private keys such as sending
+ bitcoins
+
+ Note: Issuing the walletpassphrase command while the wallet is already unlocked
+ will set a new unlock time that overrides the old one.
+
+ @since 0.3.0.0
+-}
+walletPassphrase ::
+    -- | The wallet passphrase
+    Text ->
+    -- | The time to keep the decryption key in seconds; capped at 100000000 (~3 years).
+    Int ->
+    BitcoindClient ()
+
+{- | Update a PSBT with input information from our wallet and then sign inputs
+ that we can sign for. Requires wallet passphrase to be set with walletpassphrase
+ call if wallet is encrypted.
+
+ @since 0.3.0.0
+-}
+processPsbt ::
+    -- | The transaction base64 string
+    Text ->
+    -- | Also sign the transaction when updating
+    Maybe Bool ->
+    -- | The signature hash type to sign with if not specified by the PSBT. Must
+    -- be one of "ALL" "NONE" "SINGLE" "ALL|ANYONECANPAY" "NONE|ANYONECANPAY"
+    -- "SINGLE|ANYONECANPAY"
+    Maybe Text ->
+    -- | Include BIP 32 derivation paths for public keys if we know them
+    Maybe Bool ->
+    BitcoindClient ProcessPsbtResponse
+processPsbt psbt sign = processPsbt_ psbt sign . fromMaybe "ALL"
+
+processPsbt_ ::
+    Text ->
+    Maybe Bool ->
+    Text ->
+    Maybe Bool ->
+    BitcoindClient ProcessPsbtResponse

--- a/bitcoind-rpc/src/Data/Aeson/Utils.hs
+++ b/bitcoind-rpc/src/Data/Aeson/Utils.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- |
+ Module: Data.Aeson.Utils
+
+ Helper functions for JSON (de)serialization
+-}
+module Data.Aeson.Utils (
+    partialObject,
+    (.=?),
+    utcTime,
+    toSatoshis,
+    satsPerBTC,
+    satsToBTCText,
+    decodeFromHex,
+    rangeToJSON,
+    HexEncoded (..),
+    Base64Encoded (..),
+) where
+
+import Control.Monad ((<=<), (>=>))
+import Data.Aeson (
+    FromJSON (..),
+    ToJSON (..),
+    Value,
+    object,
+    withText,
+    (.=),
+ )
+import Data.Aeson.Types (Pair)
+import Data.Bifunctor (first)
+import Data.ByteString.Base64 (decodeBase64, encodeBase64)
+import Data.Maybe (catMaybes)
+import Data.Scientific (Scientific)
+import Data.Serialize (Serialize, decode)
+import qualified Data.Serialize as S
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Text.Encoding (encodeUtf8)
+import Data.Time (UTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Word (Word64)
+import Haskoin.Util (decodeHex, encodeHex)
+
+partialObject :: [Maybe Pair] -> Value
+partialObject = object . catMaybes
+
+(.=?) :: ToJSON a => Text -> Maybe a -> Maybe (Text, Value)
+k .=? mv = (k .=) <$> mv
+
+-- | Helper function for decoding POSIX timestamps
+utcTime :: Word64 -> UTCTime
+utcTime = posixSecondsToUTCTime . fromIntegral
+
+-- | Convert BTC to Satoshis
+toSatoshis :: Scientific -> Word64
+toSatoshis = floor . (* satsPerBTC)
+
+satsPerBTC :: Num a => a
+satsPerBTC = 1_0000_0000
+
+-- | Convert sats to BTC
+satsToBTCText :: Word64 -> Text
+satsToBTCText = Text.pack . show . (/ 1_0000_0000) . fromIntegral @_ @Scientific
+
+rangeToJSON :: (Int, Maybe Int) -> Value
+rangeToJSON (n, Just m) = toJSON [n, m]
+rangeToJSON (n, _) = toJSON n
+
+-- | Read a serializable from a hex string
+decodeFromHex :: Serialize a => Text -> Either String a
+decodeFromHex = maybe (Left "Invalid hex") Right . decodeHex >=> decode
+
+newtype HexEncoded a = HexEncoded {unHexEncoded :: a} deriving (Eq, Show)
+
+instance Serialize a => FromJSON (HexEncoded a) where
+    parseJSON = withText "HexEncoded" $ either fail (return . HexEncoded) . decodeFromHex
+
+instance Serialize a => ToJSON (HexEncoded a) where
+    toJSON = toJSON . encodeHex . S.encode . unHexEncoded
+
+newtype Base64Encoded a = Base64Encoded {unBase64Encoded :: a} deriving (Eq, Show)
+
+instance Serialize a => FromJSON (Base64Encoded a) where
+    parseJSON =
+        withText "Base64Encoded" $
+            either fail (pure . Base64Encoded)
+                . (S.decode <=< first Text.unpack . decodeBase64)
+                . encodeUtf8
+
+instance Serialize a => ToJSON (Base64Encoded a) where
+    toJSON = toJSON . encodeBase64 . S.encode . unBase64Encoded

--- a/bitcoind-rpc/src/Servant/Bitcoind.hs
+++ b/bitcoind-rpc/src/Servant/Bitcoind.hs
@@ -41,6 +41,8 @@ import Data.Aeson (
     FromJSON (..),
     ToJSON (..),
     Value (Null),
+    object,
+    (.=),
  )
 import qualified Data.Aeson.Types as Ae
 import Data.Bifunctor (first)
@@ -63,6 +65,14 @@ data BitcoindException
     | ClientException ClientError
     | DecodingError String
     deriving (Show)
+
+instance ToJSON BitcoindException where
+    toJSON err = object ["type" .= theType, "error" .= theError]
+      where
+        (theType, theError) = case err of
+            RpcException rpcError -> ("RpcException" :: Text, rpcError)
+            ClientException clientError -> ("ClientException", show clientError)
+            DecodingError decodingError -> ("DecodingError", decodingError)
 
 instance Exception BitcoindException
 

--- a/bitcoind-rpc/src/Servant/Bitcoind.hs
+++ b/bitcoind-rpc/src/Servant/Bitcoind.hs
@@ -138,7 +138,7 @@ instance
 
 type BitcoindRpc m = BasicAuth "bitcoind" () :> JsonRpc m [Value] String Value
 
-type BitcoindClient r = ReaderT BasicAuthData (ExceptT BitcoindException ClientM) r
+type BitcoindClient = ReaderT BasicAuthData (ExceptT BitcoindException ClientM)
 
 type NakedClient =
     BasicAuthData ->

--- a/nix/bitcoind-versions.nix
+++ b/nix/bitcoind-versions.nix
@@ -18,4 +18,9 @@
     url = "https://bitcoincore.org/bin/bitcoin-core-0.21.0/bitcoin-0.21.0-x86_64-linux-gnu.tar.gz";
     sha256 = "1kfx4wbigrgiwx3s7609wp4g371b63r1hvij83h25i1j3dm4wijv";
   };
+
+  v0-21-1 = builtins.fetchTarball {
+    url = "https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-x86_64-linux-gnu.tar.gz";
+    sha256 = "05zn4dizi4kwbqid0vds90dwap6k6zrg8pv8qc7sxv2wg82klv9q";
+  };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,37 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let bitcoindVersions = import ./bitcoind-versions.nix;
+    mkBitcoindShell = bitcoindVersion:
+      pkgs.mkShell {
+        buildInputs = [
+          pkgs.secp256k1
+          pkgs.gmp
+          pkgs.zlib
+        ];
+
+        shellHook =
+          ''
+          export PATH="${bitcoindVersion}/bin:$PATH"
+
+          rpc_user=user
+          rpc_pass=password
+
+          start_bitcoind () {
+            bitcoind -daemon -regtest -rpcuser=$rpc_user -rpcpassword=$rpc_pass
+          }
+
+          alias bcli="bitcoin-cli -regtest -rpcuser=$rpc_user -rpcpassword=$rpc_pass"
+
+          echo "Start a regtest node with 'start_bitcoind'"
+          echo "Access the node with 'bcli'"
+          '';
+      };
+in
+
+{
+  v0-19-1 = mkBitcoindShell bitcoindVersions.v0-19-1;
+  v0-20-0 = mkBitcoindShell bitcoindVersions.v0-20-0;
+  v0-20-1 = mkBitcoindShell bitcoindVersions.v0-20-1;
+  v0-21-0 = mkBitcoindShell bitcoindVersions.v0-21-0;
+  v0-21-1 = mkBitcoindShell bitcoindVersions.v0-21-1;
+}


### PR DESCRIPTION
This change implements much of the wallet RPC and adds some non-wallet PSBT calls.  Other changes include:

* I changed the way that we deal with optional parameters (drop nulls at the end of the parameter list)
* Use `Word64` instead of `Word32` for satoshis
* Make the node version available in `bitcoind-regtest`
* Added nix shell definitions for versions of bitcoind:  `nix-shell -A v0-20-0 nix/shell.nix`