### PR TITLE
Significantly improve generator

### DIFF
--- a/bitcoind-regtest/autominer/Main.hs
+++ b/bitcoind-regtest/autominer/Main.hs
@@ -76,7 +76,12 @@ main = do
                 waitSync
 
         putStrLn "Generating blocks..."
-        generateWithTransactions mgr nodeHandle (blockInterval config) (pure Nothing) oscillatingFeeRate
+        generateWithTransactions
+            mgr
+            nodeHandle
+            (blockInterval config)
+            (pure Nothing)
+            oscillatingFeeRate
 
 oscillatingFeeRate :: BlockHeight -> Word64
 oscillatingFeeRate n

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -19,6 +19,7 @@ common core
         , base >=4.12 && <4.16
         , base64 ^>=0.4
         , bitcoind-rpc ^>=0.3
+        , bytestring >=0.10 && <0.12
         , cereal ^>=0.5
         , directory ^>=1.3
         , haskoin-core >=0.15 && <0.22

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -1,47 +1,84 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module Bitcoin.Core.Regtest.Generator (
     generateWithTransactions,
 ) where
 
+import Bitcoin.Core.RPC (
+    BitcoindClient,
+    ListUnspentOptions (ListUnspentOptions),
+ )
+import qualified Bitcoin.Core.RPC as RPC
+import Bitcoin.Core.Regtest.Framework (NodeHandle, oneBitcoin, runBitcoind)
+import Control.Arrow ((&&&))
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, link)
 import Control.Exception (throwIO)
-import Control.Monad (forever, replicateM)
+import Control.Monad (forever, replicateM, when, (>=>))
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict (
+    StateT (StateT),
+    evalStateT,
+    gets,
+    mapStateT,
+    modify',
+ )
+import Data.ByteString (ByteString)
+import Data.Functor (void)
+import Data.List (uncons, unfoldr)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 import qualified Data.Serialize as S
+import Data.Text (Text)
 import Data.Word (Word64)
-import Haskoin.Block (BlockHeight, blockTxns)
+import Haskoin (
+    Script (Script),
+    TxHash,
+    TxIn (TxIn),
+ )
+import qualified Haskoin as H
+import Haskoin.Block (BlockHeight)
 import Haskoin.Transaction (
     OutPoint (..),
     Tx (..),
     TxOut (..),
-    txHash,
  )
 import Network.HTTP.Client (Manager)
 
-import qualified Bitcoin.Core.RPC as RPC
-import Bitcoin.Core.Regtest.Framework (NodeHandle, runBitcoind)
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.State.Strict (evalStateT, get, gets, modify, put)
-import Data.ByteString.Base64 (encodeBase64)
-import Data.Maybe (fromJust)
-import Data.Sequence (Seq ((:<|)), (|>))
-import Data.Text (Text)
+-- | How much to pay out on each faucet request
+faucetPayment :: Word64
+faucetPayment = oneBitcoin
 
-processCoinbase :: Tx -> (OutPoint, Word64)
-processCoinbase tx0 = (OutPoint (txHash tx0) 0, outValue . head $ txOut tx0)
+-- | If the series count exceeds this value, stop generating series
+maxSeries :: Int
+maxSeries = seriesLength * seriesCount
 
-data GeneratorState = GeneratorState
-    { generatorSpendableOutputs :: [(OutPoint, Word64)]
-    , generatorUnspentCoinbases :: Seq (OutPoint, Word64)
-    }
+-- | The number of series in a group
+seriesCount :: Int
+seriesCount = length outputsPerSeries
 
-{- | Generate many transactions per block with a certain mean fee rate
+-- | How many transactions in a series to broadcast
+seriesLength :: Int
+seriesLength = 10
 
-FIXME For some reason @bitcoind@ refuses to sign transactions if we set
- @splitCount@ too high.  What's going on here?
--}
+-- | Initial amount per output
+amountPerOutput :: Word64
+amountPerOutput = 20000
+
+-- | This value determines the transaction series that will fill up the mempool
+outputsPerSeries :: [Word64]
+outputsPerSeries =
+    mconcat
+        [ replicate 20 100 -- 20 txs with 100 outputs
+        , replicate 30 5 -- 30 txs with 5 outputs
+        , replicate 100 2 -- 100 txs with 2 outputs
+        ]
+
+-- | Generate many transactions per block with a certain mean fee rate
 generateWithTransactions ::
     Manager ->
     NodeHandle ->
@@ -52,129 +89,236 @@ generateWithTransactions ::
     -- | Mean fee rate at height
     (BlockHeight -> Word64) ->
     IO ()
-generateWithTransactions mgr nodeHandle blockInterval getExternalAddress getMeanFeeRate =
-    either throwIO pure =<< runBitcoind mgr nodeHandle generator
-  where
-    generator = flip evalStateT emptyState $ do
-        initialize
-        forever $ do
-            sendTransactions
-            generatorGenerate
-            liftIO $ threadDelay (blockInterval * 1_000_000)
+generateWithTransactions mgr nodeHandle blockInterval getExternalAddress getMeanFeeRate = do
+    run initialize
 
-    emptyState = GeneratorState mempty mempty
+    (async >=> link) . run . RPC.withWallet miningWallet . waitRepeat 1 $ do
+        balance <- getBalance
+        when (balance >= faucetPayment) $
+            liftIO getExternalAddress >>= mapM_ fundAddress
+
+    run . flip evalStateT mempty . waitRepeat blockInterval $ do
+        mapStateT (RPC.withWallet floodingWallet) $ txFlood getMeanFeeRate
+        lift . generatorGenerate =<< getSeriesCount
+  where
+    run = runBitcoind mgr nodeHandle >=> either throwIO pure
+
+    miningWallet = "bitcoin-regtest-generator.mine"
+    floodingWallet = "bitcoin-regtest-generator.flood"
+    password = "password"
+
+    newWallet name = do
+        RPC.createWallet
+            name
+            Nothing
+            Nothing
+            password
+            Nothing
+            Nothing
+            Nothing
+            Nothing
+        RPC.withWallet name $ RPC.walletPassphrase password 10_000
 
     initialize = do
-        lift $
-            RPC.createWallet
-                "bitcoin-regtest-generator"
-                Nothing
-                Nothing
-                password
-                Nothing
-                Nothing
-                Nothing
-                Nothing
-        replicateM 100 generatorGenerate
+        newWallet miningWallet
+        newWallet floodingWallet
+        replicateM 100 $ generatorGenerate 0
 
-    generatorGenerate = do
-        coinbaseOutput <- lift $ do
-            addr <- newAddress
-            RPC.generateToAddress 1 addr Nothing
-                >>= fmap (processCoinbase . head . blockTxns)
-                    . RPC.getBlock
-                    . head
-        modify $ \state ->
-            state
-                { generatorUnspentCoinbases =
-                    generatorUnspentCoinbases state |> coinbaseOutput
-                }
+    generatorGenerate nSeries = do
+        addr <- RPC.withWallet miningWallet newAddress
+        RPC.generateToAddress 1 addr Nothing
+        balance <- RPC.withWallet miningWallet getBalance
+        when (balance >= satRequirement && nSeries <= maxSeries) fundFloodWallet
+
+    fundFloodWallet = do
+        addressAmounts <-
+            RPC.withWallet floodingWallet $
+                traverse getAddressAmount outputsPerSeries
+        feeRate <- getMeanFeeRate <$> RPC.getBlockCount
+        void . RPC.withWallet miningWallet $ spend feeRate addressAmounts
+
+    getAddressAmount nOutputs = (,amountPerOutput * nOutputs) <$> newAddress
 
     newAddress = RPC.getNewAddress Nothing Nothing
 
-    sendTransactions = do
-        lift $ RPC.walletPassphrase password (2 * blockInterval)
-        feeRate <- getMeanFeeRate <$> lift RPC.getBlockCount
-        splitOutputTxs <- spendSplitOutputs feeRate
-        coinbaseSplitTx <- popCoinbase >>= traverse (splitCoinbaseOutput feeRate)
-        lift . mapM_ (`RPC.sendTransaction` Nothing) $ splitOutputTxs
-        lift . mapM_ (`RPC.sendTransaction` Nothing) $ coinbaseSplitTx
+    fundAddress addr = do
+        feeRate <- getMeanFeeRate <$> RPC.getBlockCount
+        spend feeRate [(addr, faucetPayment)]
 
-    popCoinbase = do
-        state <- get
-        case generatorUnspentCoinbases state of
-            next :<| rest -> Just next <$ put state{generatorUnspentCoinbases = rest}
-            _ -> pure Nothing
+satRequirement :: Word64
+satRequirement = sum $ (* amountPerOutput) <$> outputsPerSeries
 
-    appendSpendable tx = modify $ \state ->
-        state
-            { generatorSpendableOutputs =
-                generatorSpendableOutputs state
-                    <> zipWith
-                        (mkSpendableOutput (txHash tx))
-                        [0 ..]
-                        (outValue <$> txOut tx)
+{- | Create many transactions and fill up blockspace.  This uses the same trick
+ as the Bitcoin Core functional tests: create anyone can spend outputs with
+ predictable outputs to avoid needing to sign.
+
+ We create sequences of transactions which start by breaking a UTXO into some number of outputs.
+ Subsequent transactions spend all the outputs of the previous transaction and create the same
+ number of outputs.
+-}
+txFlood ::
+    -- | Fee rate per block
+    (BlockHeight -> Word64) ->
+    StateT [TxSeries] BitcoindClient [TxHash]
+txFlood feeRate = do
+    balance <- lift getBalance
+    nSeries <- getSeriesCount
+    when (balance >= satRequirement && nSeries <= maxSeries) $ do
+        height <- lift RPC.getBlockCount
+        -- Create a series out of every unspent output
+        unspentOutputs <- lift getUnspent
+        -- We use coin control to make sure that the wallet spends outputs
+        -- in a predictable way
+        lift . RPC.lockUnspent False $ fst <$> unspentOutputs
+        mapM_ (createSeries height) unspentOutputs
+    flood
+  where
+    createSeries height (outPoint, amount) = do
+        lift $ RPC.lockUnspent True [outPoint]
+        fund (fromIntegral nOutputs) (feeRate height) amount
+      where
+        nOutputs = amount `quot` amountPerOutput
+
+    getUnspent =
+        fmap extractPointAmount
+            <$> RPC.listUnspent
+                Nothing
+                Nothing
+                Nothing
+                Nothing
+                (ListUnspentOptions Nothing Nothing Nothing Nothing)
+    extractPointAmount =
+        (OutPoint <$> RPC.outputTxId <*> RPC.outputVOut) &&& RPC.outputAmount
+
+getBalance :: BitcoindClient Word64
+getBalance = RPC.balanceDetailsTrusted . RPC.balancesMine <$> RPC.getBalances
+
+getSeriesCount :: Monad m => StateT [TxSeries] m Int
+getSeriesCount = gets length
+
+type TxSeries = [Tx]
+
+-- | Create the funding anchor for a tx series and add the tx series to the internal state
+fund ::
+    -- | Output count per transaction
+    Int ->
+    -- | Fee rate
+    Word64 ->
+    -- | Sats to allocate
+    Word64 ->
+    StateT [TxSeries] BitcoindClient TxHash
+fund nOutputs feeRate sats = do
+    (value, outPoint) <- lift createFundingOutput
+    modify' $ (:) (take seriesLength $ txSeries nOutputs feePerOutput value outPoint)
+    pure $ H.outPointHash outPoint
+  where
+    createFundingOutput = do
+        tx <- createRoot >>= (`RPC.getRawTransaction` Nothing)
+        pure
+            ( H.outValue . head $ H.txOut tx
+            , OutPoint (H.txHash tx) 0
+            )
+
+    createRoot =
+        RPC.sendToAddress
+            easySpendAddress
+            sats
+            Nothing
+            Nothing
+            (Just True)
+            Nothing
+            Nothing
+            Nothing
+            Nothing
+            (Just feeRate)
+
+    feePerOutput = feeRate * 75 -- tuned via testing
+
+-- | Peel off the next transaction from each series and broadcast it
+flood :: StateT [TxSeries] BitcoindClient [TxHash]
+flood = StateT (pure . advance) >>= lift . traverse (`RPC.sendTransaction` Nothing)
+
+advance :: [TxSeries] -> ([Tx], [TxSeries])
+advance = peelFirst &&& dropFirst
+  where
+    peelFirst = mapMaybe (fmap fst . uncons)
+    dropFirst = filter (not . null) . fmap (drop 1)
+
+{- | Construct a sequence of transactions each of which spends all of the inputs of the previous
+ one, creating the same number of outputs
+-}
+txSeries ::
+    -- | Number of outputs
+    Int ->
+    -- | Fee per output
+    Word64 ->
+    -- | Funds for the series
+    Word64 ->
+    OutPoint ->
+    TxSeries
+txSeries nOutputs feePerOutput totalSats fundingPoint =
+    unfoldr (sequence . (id &&& getNext)) tx0
+  where
+    tx0 =
+        Tx
+            { H.txVersion = 2
+            , H.txIn = [spendEasy fundingPoint]
+            , H.txOut = replicate nOutputs $ easySpendOutput satsPerOutput0
+            , H.txWitness = mempty
+            , H.txLockTime = 0
             }
-    mkSpendableOutput txId ix amount = (OutPoint txId ix, amount)
+    satsPerOutput0 = (totalSats `quot` fromIntegral nOutputs) - feePerOutput
 
-    splitCoinbaseOutput feeRate (coinbaseOutput, amount) = do
-        recipients <- lift $ replicateM splitCount newAddress
-        let outputs = zip recipients amounts
-        tx <- lift $ spendOutput feeRate coinbaseOutput outputs
-        appendSpendable tx
-        pure tx
+    getNext prevTx
+        | satsPerOutput > 2 * feePerOutput =
+            Just
+                Tx
+                    { H.txVersion = 2
+                    , H.txIn = spendEasy <$> outPoints prevTx
+                    , H.txOut = replicate nOutputs $ easySpendOutput satsPerOutput
+                    , H.txWitness = mempty
+                    , H.txLockTime = 0
+                    }
+        | otherwise = Nothing
       where
-        (q, r) = amount `quotRem` splitCount
-        amounts = (q +) <$> (replicate (fromIntegral r) 1 <> repeat 0)
-        splitCount :: Num a => a
-        splitCount = 20
+        satsPerOutput = (H.outValue . head . H.txOut) prevTx - feePerOutput
 
-    useSpendable = do
-        spendableOutputs <- gets generatorSpendableOutputs
-        modify $ \state -> state{generatorSpendableOutputs = mempty}
-        pure spendableOutputs
+    outPoints tx = OutPoint (H.txHash tx) <$> [0 .. (fromIntegral . length . H.txOut) tx - 1]
 
-    spendSplitOutputs feeRate = useSpendable >>= lift . traverse (spendSplitOutput feeRate)
-    spendSplitOutput feeRate (outPoint, amount) = do
-        recipient <- liftIO getExternalAddress >>= maybe newAddress pure
-        spendOutput feeRate outPoint [(recipient, amount)]
+spend ::
+    Word64 ->
+    [(Text, Word64)] ->
+    BitcoindClient TxHash
+spend feeRate addrAmounts =
+    RPC.sendMany
+        (Map.fromList addrAmounts)
+        Nothing
+        mempty
+        Nothing
+        Nothing
+        Nothing
+        (Just feeRate)
 
-    password = "password"
+easySpendAddress :: Text
+Just easySpendAddress =
+    H.addrToText H.btcRegTest =<< (H.outputAddress . H.toP2SH) (Script mempty)
 
-    spendOutput feeRate inputOutPoint outputs = do
-        psbt0 <-
-            RPC.createPsbtPsbt
-                <$> RPC.createFundedPsbt [psbtInput] psbtOutputs Nothing (Just options) Nothing
-        psbt1 <-
-            RPC.processPsbtPsbt
-                <$> RPC.processPsbt (psbtText psbt0) (Just True) Nothing Nothing
-        finalizePsbtResponse <- RPC.finalizePsbt (psbtText psbt1) (Just True)
-        pure . fromJust $ RPC.finalizedTx finalizePsbtResponse
-      where
-        psbtInput =
-            RPC.PsbtInput
-                { RPC.psbtInputTx = outPointHash inputOutPoint
-                , RPC.psbtInputVOut = outPointIndex inputOutPoint
-                , RPC.psbtInputSequence = Nothing
-                }
-        psbtOutputs =
-            RPC.PsbtOutputs
-                { RPC.psbtOutputAddrs = outputs
-                , RPC.psbtOutputData = Nothing
-                }
-        options =
-            RPC.CreatePsbtOptions
-                { RPC.createPsbtAddInputs = Just False
-                , RPC.createPsbtChangeAddress = Nothing
-                , RPC.createPsbtChangePosition = Nothing
-                , RPC.createPsbtChangeType = Nothing
-                , RPC.createPsbtIncludeWatching = Nothing
-                , RPC.createPsbtLockUnspents = Nothing
-                , RPC.createPsbtFeeRate = Just feeRate
-                , RPC.createPsbtSubtractFee = [0 .. length outputs - 1]
-                , RPC.createPsbtReplaceable = Nothing
-                , RPC.createPsbtConfTarget = Nothing
-                , RPC.createPsbtEstimateMode = Nothing
-                }
+easySpendScriptOutput :: ByteString
+easySpendScriptOutput = H.encodeOutputBS . H.toP2SH $ Script mempty
 
-    psbtText = encodeBase64 . S.encode
+-- | Produce an output that we can spend without signing
+easySpendOutput :: Word64 -> TxOut
+easySpendOutput outValue = TxOut{H.outValue, H.scriptOutput = easySpendScriptOutput}
+
+-- | Produce an input that spends an output created with 'easySpendOutput'
+spendEasy :: OutPoint -> TxIn
+spendEasy prevOutput =
+    TxIn
+        { H.prevOutput
+        , H.scriptInput = S.encode $ Script [H.OP_1, H.opPushData (S.encode $ Script mempty)]
+        , H.txInSequence = maxBound
+        }
+
+waitRepeat :: MonadIO m => Int -> m a -> m ()
+waitRepeat delayInSecs task =
+    forever $ task >> (liftIO . threadDelay) (delayInSecs * 1_000_000)

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -105,19 +105,17 @@ generateWithTransactions mgr nodeHandle blockInterval getExternalAddress getMean
 
     miningWallet = "bitcoin-regtest-generator.mine"
     floodingWallet = "bitcoin-regtest-generator.flood"
-    password = "password"
 
     newWallet name = do
         RPC.createWallet
             name
             Nothing
             Nothing
-            password
+            mempty
             Nothing
             Nothing
             Nothing
             Nothing
-        RPC.withWallet name $ RPC.walletPassphrase password 10_000
 
     initialize = do
         newWallet miningWallet

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
@@ -13,10 +13,9 @@ import Bitcoin.Core.Regtest (
  )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (async, cancel, link)
-import Control.Monad (forM_, unless, (>=>))
+import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
-import Data.Bifunctor (first)
-import Haskoin (Block, BlockHeight, blockTxns)
+import Haskoin (BlockHeight)
 import Network.HTTP.Client (Manager)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps, (@?=))
@@ -31,17 +30,11 @@ testGenerator mgr = testCaseSteps "generateWithTransactions" $ \step ->
         runBitcoind mgr nodeHandle $ waitForBlocks 120
         cancel h
 
-        forM_ [102 .. 120] $ \blockHeight -> do
-            Right block <- runBitcoind mgr nodeHandle $ getBlockAtHeight blockHeight
-            length (blockTxns block) @?= 22
-
-        feeResponse <-
+        Right feeResponse <-
             runBitcoind mgr nodeHandle $
                 RPC.estimateSmartFeeFee <$> RPC.estimateSmartFee 6 Nothing
-        first show feeResponse @?= Right (Just 20)
-
-getBlockAtHeight :: BlockHeight -> BitcoindClient Block
-getBlockAtHeight = RPC.getBlockHash >=> RPC.getBlock
+        fmap (> 18) feeResponse @?= Just True
+        fmap (< 23) feeResponse @?= Just True
 
 waitForBlocks :: BlockHeight -> BitcoindClient ()
 waitForBlocks targetHeight = loop

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
@@ -7,8 +7,6 @@ module Bitcoin.Core.Test.Utils (
 
     -- * Wallet
     createWallet,
-    walletPassword,
-    unlockWallet,
     initWallet,
     generate,
     toInput,
@@ -44,17 +42,11 @@ createWallet walletName =
         walletName
         Nothing
         Nothing
-        walletPassword
+        mempty
         (Just True)
         Nothing
         Nothing
         Nothing
-
-walletPassword :: Text
-walletPassword = "password"
-
-unlockWallet :: BitcoindClient ()
-unlockWallet = RPC.walletPassphrase walletPassword 10
 
 initWallet :: Text -> BitcoindClient ()
 initWallet name = void $ createWallet name

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
@@ -35,13 +35,10 @@ import qualified Bitcoin.Core.RPC as RPC
 import Bitcoin.Core.Regtest (NodeHandle, Version, nodeVersion, v20_1, v21_1)
 import Bitcoin.Core.Test.Utils (
     bitcoindTest,
-    createWallet,
     generate,
     initWallet,
     shouldMatch,
     testRpc,
-    unlockWallet,
-    walletPassword,
  )
 
 walletRPC :: Manager -> NodeHandle -> TestTree
@@ -62,7 +59,16 @@ walletRPC mgr h =
 
 testWalletCommands :: BitcoindClient ()
 testWalletCommands = do
-    loadWalletR <- createWallet walletName
+    loadWalletR <-
+        RPC.createWallet
+            walletName
+            Nothing
+            Nothing
+            walletPassword
+            (Just True)
+            Nothing
+            Nothing
+            Nothing
     liftIO $ RPC.loadWalletName loadWalletR @?= walletName
 
     RPC.listWallets >>= shouldMatch [walletName] . filter (not . Text.null)
@@ -82,7 +88,7 @@ testWalletCommands = do
     RPC.abortRescan
 
     RPC.walletLock
-    RPC.walletPassphrase "password" 60
+    RPC.walletPassphrase walletPassword 60
 
     RPC.setTxFee 1000
 
@@ -98,6 +104,7 @@ testWalletCommands = do
     void $ RPC.unloadWallet (Just walletName) Nothing
   where
     walletName = "testCreateWallet"
+    walletPassword = "abc123"
 
 testAddressCommands :: BitcoindClient ()
 testAddressCommands = do
@@ -126,7 +133,6 @@ testAddressCommands = do
         RPC.getAddressesByLabel label3 >>= shouldMatch [(newAddress, PurposeRecv)] . Map.toList
 
         RPC.addMultisigAddress 2 [newAddress2, newAddress3, newAddress4] Nothing Nothing
-        unlockWallet
         privKey <- RPC.dumpPrivKey newAddress
 
         signingAddress <- RPC.getNewAddress Nothing (Just Legacy)
@@ -135,7 +141,6 @@ testAddressCommands = do
         pure (privKey, newAddress2)
 
     withWallet wallet2 $ do
-        unlockWallet
         RPC.importPrivKey privKey (Just "priv-test") Nothing
         RPC.importAddress someAddress (Just "addr-test") (Just True) Nothing
   where
@@ -154,7 +159,6 @@ testTransactionCommands = do
 
     txId <- withWallet minerWallet $ do
         replicateM_ 200 generate
-        unlockWallet
         txId <- sendSimple addressA1 sendAmount1 "funding" "user-a"
         replicateM_ 200 generate
         pure txId
@@ -187,7 +191,6 @@ testTransactionCommands = do
         RPC.lockUnspent False $ toOutPoint <$> unspent
         RPC.listLockUnspent >>= shouldMatch (toOutPoint <$> unspent)
 
-        unlockWallet
         RPC.lockUnspent True $ toOutPoint <$> unspent
         txId2 <-
             RPC.sendMany
@@ -235,9 +238,8 @@ toOutPoint = OutPoint <$> RPC.outputTxId <*> fromIntegral . RPC.outputVOut
 
 testDescriptorCommands :: Version -> BitcoindClient ()
 testDescriptorCommands v = do
-    RPC.createWallet walletName Nothing Nothing walletPassword (Just True) (Just True) Nothing Nothing
+    RPC.createWallet walletName Nothing Nothing mempty (Just True) (Just True) Nothing Nothing
     withWallet walletName $ do
-        RPC.walletPassphrase walletPassword 30
         RPC.getNewAddress (Just "internal") Nothing
         RPC.importDescriptors
             [ DescriptorRequest
@@ -295,7 +297,6 @@ testPsbtCommands = do
                 }
 
     void . withWallet walletA $ do
-        unlockWallet
         RPC.createFundedPsbt mempty outputs Nothing (Just options) (Just True)
   where
     walletA = "psbtWallet-A"

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
@@ -27,7 +27,6 @@ import Bitcoin.Core.RPC (
     DescriptorRequest (DescriptorRequest),
     ListUnspentOptions (ListUnspentOptions),
     OutputDetails,
-    PrevTx (PrevTx),
     PsbtOutputs (PsbtOutputs),
     Purpose (PurposeRecv),
     withWallet,
@@ -185,11 +184,11 @@ testTransactionCommands = do
                 (Just True)
                 (ListUnspentOptions Nothing Nothing Nothing Nothing)
         liftIO . assertBool "At least one output" $ (not . null) unspent
-        RPC.lockUnspent False $ toPrevTx <$> unspent
+        RPC.lockUnspent False $ toOutPoint <$> unspent
         RPC.listLockUnspent >>= shouldMatch (toOutPoint <$> unspent)
 
         unlockWallet
-        RPC.lockUnspent True $ toPrevTx <$> unspent
+        RPC.lockUnspent True $ toOutPoint <$> unspent
         txId2 <-
             RPC.sendMany
                 (Map.fromList $ (,100_000) <$> addrs)
@@ -230,15 +229,6 @@ testTransactionCommands = do
             Nothing
             (Just True)
             (Just 1)
-
-    toPrevTx =
-        PrevTx
-            <$> RPC.outputTxId
-            <*> RPC.outputVOut
-            <*> RPC.outputScriptPubKey
-            <*> pure Nothing
-            <*> pure Nothing
-            <*> RPC.outputAmount
 
 toOutPoint :: OutputDetails -> OutPoint
 toOutPoint = OutPoint <$> RPC.outputTxId <*> fromIntegral . RPC.outputVOut


### PR DESCRIPTION
This rewrites the chain generator to produce enough transactions to fill the mempool, thus setting a minimum fee.  I took a trick from the Bitcoin Core functional tests: use anyone can spend outputs to avoid the overhead of signing large numbers of outputs.