### PR TITLE
Bug fix and upgrade to autominer

### DIFF
--- a/bitcoind-regtest/autominer/Main.hs
+++ b/bitcoind-regtest/autominer/Main.hs
@@ -93,7 +93,9 @@ waitSync = do
     getPeerInfo >>= maybe retry onPeerInfo . listToMaybe
   where
     onPeerInfo peerInfo
-        | syncedBlocks peerInfo < startingHeight peerInfo = retry
+        | Just synced <- syncedBlocks peerInfo
+        , synced < startingHeight peerInfo =
+            retry
         | otherwise = pure ()
     retry = do
         liftIO $ putStrLn "Waiting for sync"

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
@@ -15,6 +15,7 @@ module Bitcoin.Core.Regtest (
     spendPackageOutputs,
 
     -- * Simulation
+    Funding (..),
     generateWithTransactions,
 
     -- * Internal wallet


### PR DESCRIPTION
The `getpeerinfo` RPC did not cover all possible responses, so I updated the response type.

This changes the autominer in two ways.  First, users can run the autominer either as a faucet or by giving an initial list of addresses and amounts to fund.  Second, the autominer will try to sweep anyone-can-spend outputs created on a previous run instead of mining 100 blocks when possible.