### PR TITLE
Update cabal dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist-newstyle/
 /result
 *.out
 /cabal.project.local
+TAGS

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -25,8 +25,8 @@ common core
         , haskoin-core >=0.15 && <0.22
         , http-client >=0.6 && <0.8
         , process ^>=1.6
-        , servant >=0.15 && <0.19
-        , servant-client >=0.15 && <0.19
+        , servant >=0.15 && <0.20
+        , servant-client >=0.15 && <0.20
         , temporary ^>=1.3
         , text ^>=1.2
 

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -31,7 +31,7 @@ library
         Servant.Bitcoind
 
     build-depends:
-          aeson >=1.4 && <2.1
+          aeson >=2.0 && <2.1
         , base >=4.12 && <4.16
         , base64 ^>=0.4
         , bytestring >=0.10 && <0.12
@@ -49,3 +49,4 @@ library
         , text ^>=1.2
         , time >=1.8 && <1.14
         , transformers >=0.5 && <0.7
+

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -43,8 +43,8 @@ library
         , http-types ^>=0.12
         , mtl ^>=2.2
         , scientific ^>=0.3
-        , servant >=0.15 && <0.19
-        , servant-client >=0.15 && <0.19
+        , servant >=0.15 && <0.20
+        , servant-client >=0.15 && <0.20
         , servant-jsonrpc-client >=1.0 && <1.2
         , text ^>=1.2
         , time >=1.8 && <1.14

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
@@ -32,6 +32,7 @@ module Bitcoin.Core.RPC.Transactions (
 
 import Data.Aeson (
     FromJSON (..),
+    Key,
     ToJSON (toJSON),
     object,
     withObject,
@@ -247,7 +248,7 @@ instance ToJSON PsbtInput where
 
 -- | @since 0.3.0.0
 data PsbtOutputs = PsbtOutputs
-    { psbtOutputAddrs :: [(Text, Word64)]
+    { psbtOutputAddrs :: [(Key, Word64)]
     , psbtOutputData :: Maybe Text
     }
     deriving (Eq, Show)

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
@@ -32,7 +32,6 @@ module Bitcoin.Core.RPC.Transactions (
 
 import Data.Aeson (
     FromJSON (..),
-    Key,
     ToJSON (toJSON),
     object,
     withObject,
@@ -41,16 +40,7 @@ import Data.Aeson (
     (.:?),
     (.=),
  )
-import Data.Proxy (Proxy (..))
-import Data.Scientific (Scientific)
-import qualified Data.Serialize as S
-import Data.Text (Text)
-import Data.Word (Word32, Word64)
-import Haskoin.Block (BlockHash, BlockHeight)
-import Haskoin.Transaction (PartiallySignedTransaction, Tx, TxHash)
-import Haskoin.Util (encodeHex)
-import Servant.API ((:<|>) (..))
-
+import qualified Data.Aeson.Key as K
 import Data.Aeson.Utils (
     Base64Encoded,
     HexEncoded (HexEncoded, unHexEncoded),
@@ -63,7 +53,16 @@ import Data.Aeson.Utils (
     (.=?),
  )
 import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (..))
+import Data.Scientific (Scientific)
+import qualified Data.Serialize as S
+import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Word (Word32, Word64)
+import Haskoin.Block (BlockHash, BlockHeight)
+import Haskoin.Transaction (PartiallySignedTransaction, Tx, TxHash)
+import Haskoin.Util (encodeHex)
+import Servant.API ((:<|>) (..))
 import Servant.Bitcoind (
     BitcoindClient,
     BitcoindEndpoint,
@@ -248,7 +247,7 @@ instance ToJSON PsbtInput where
 
 -- | @since 0.3.0.0
 data PsbtOutputs = PsbtOutputs
-    { psbtOutputAddrs :: [(Key, Word64)]
+    { psbtOutputAddrs :: [(Text, Word64)]
     , psbtOutputData :: Maybe Text
     }
     deriving (Eq, Show)
@@ -259,7 +258,7 @@ instance ToJSON PsbtOutputs where
             (fmap toAddrObject . psbtOutputAddrs) outputs
                 <> (foldMap toDataObject . psbtOutputData) outputs
       where
-        toAddrObject (addr, amount) = object [addr .= satsToBTCText amount]
+        toAddrObject (addr, amount) = object [K.fromText addr .= satsToBTCText amount]
         toDataObject hex = [object ["data" .= hex]]
 
 {- | Creates a transaction in the Partially Signed Transaction format. Implements the Creator role.

--- a/bitcoind-rpc/src/Data/Aeson/Utils.hs
+++ b/bitcoind-rpc/src/Data/Aeson/Utils.hs
@@ -22,6 +22,7 @@ module Data.Aeson.Utils (
 import Control.Monad ((<=<), (>=>))
 import Data.Aeson (
     FromJSON (..),
+    Key,
     ToJSON (..),
     Value,
     object,
@@ -46,7 +47,7 @@ import Haskoin.Util (decodeHex, encodeHex)
 partialObject :: [Maybe Pair] -> Value
 partialObject = object . catMaybes
 
-(.=?) :: ToJSON a => Text -> Maybe a -> Maybe (Text, Value)
+(.=?) :: ToJSON a => Key -> Maybe a -> Maybe Pair
 k .=? mv = (k .=) <$> mv
 
 -- | Helper function for decoding POSIX timestamps

--- a/bitcoind-rpc/src/Servant/Bitcoind.hs
+++ b/bitcoind-rpc/src/Servant/Bitcoind.hs
@@ -51,6 +51,7 @@ import Data.Aeson (
  )
 import qualified Data.Aeson.Types as Ae
 import Data.Bifunctor (first)
+import Data.Kind (Type)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import GHC.TypeLits (KnownSymbol, Symbol)
@@ -123,7 +124,7 @@ data DefZero
 instance Num a => HasDefault DefZero a where getDefault _ = 0
 
 class HasBitcoindClient x where
-    type TheBitcoindClient x :: *
+    type TheBitcoindClient x :: Type
     toBitcoindClient :: p x -> TheBitcoindClient x
 
 instance
@@ -198,8 +199,8 @@ type NakedClient =
  functions with endpoint specific arguments.
 -}
 class Rewrite a where
-    type RewriteFrom a :: *
-    type RewriteTo a :: *
+    type RewriteFrom a :: Type
+    type RewriteTo a :: Type
     rewriteRpc :: p a -> RewriteFrom a -> RewriteTo a
 
 -- | Handle endpoints which do not have an expected return value


### PR DESCRIPTION
- Updated dependencies of Servant to support the newest versions in Stackage
- Fixed the warning about reliance on `StarIsType`, by replacing `*` with Data.Kind.Type