### PR TITLE
Autominer performance and launcher API

### DIFF
--- a/bitcoind-regtest/autominer/Main.hs
+++ b/bitcoind-regtest/autominer/Main.hs
@@ -86,7 +86,7 @@ main :: IO ()
 main = do
     mgr <- newManager defaultManagerSettings
     config <- Opt.execParser options
-    withBitcoind (basePort config) $ \nodeHandle -> do
+    withBitcoind (basePort config) Nothing $ \nodeHandle -> do
         putStrLn $ "Listening for peers on 127.0.0.1:" <> show (nodeP2pPort nodeHandle)
         forM_ (show <$> peerPort config) $ \thePeerPort -> do
             putStrLn $ "Connecting to a peer on port " <> thePeerPort

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -16,7 +16,7 @@ common core
     ghc-options:      -Wall -fno-warn-unused-do-bind
     build-depends:
           async >=2.0 && <2.3
-        , base >=4.12 && <4.16
+        , base >=4.12 && <4.17
         , base64 ^>=0.4
         , bitcoind-rpc ^>=0.3
         , bytestring >=0.10 && <0.12
@@ -28,7 +28,7 @@ common core
         , servant >=0.15 && <0.20
         , servant-client >=0.15 && <0.20
         , temporary ^>=1.3
-        , text ^>=1.2
+        , text >=1.2 && <2.1
 
 library
     import:         core
@@ -53,7 +53,7 @@ executable bitcoind-rpc-explorer
     build-depends:
           bitcoind-regtest
         , bytestring >=0.10 && <0.12
-        , optparse-applicative >=0.14 && <0.17
+        , optparse-applicative >=0.14 && <0.20
 
 
 executable bitcoind-regtest-autominer
@@ -62,7 +62,7 @@ executable bitcoind-regtest-autominer
     hs-source-dirs: autominer/
     build-depends:
           bitcoind-regtest
-        , optparse-applicative >=0.14 && <0.17
+        , optparse-applicative >=0.14 && <0.20
 
 test-suite bitcoind-rpc-tests
     import:         core

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -60,6 +60,7 @@ executable bitcoind-regtest-autominer
     import: core
     main-is: Main.hs
     hs-source-dirs: autominer/
+    ghc-options: -threaded -O2
     build-depends:
           bitcoind-regtest
         , optparse-applicative >=0.14 && <0.20

--- a/bitcoind-regtest/rpc-explorer/Main.hs
+++ b/bitcoind-regtest/rpc-explorer/Main.hs
@@ -43,7 +43,7 @@ main = do
     outputFile <- execParser opts
     mapM_ (`writeFile` mempty) outputFile
     let writeOutput = maybe putStrLn appendFile outputFile
-    withBitcoind 8330 $ \h -> do
+    withBitcoind 8330 Nothing $ \h -> do
         rpcCommands <- parseHelpText <$> bitcoinCli h ["help"]
         writeOutput $ unlines rpcCommands
         mapM_ (getHelpText h >=> writeOutput) rpcCommands

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
@@ -6,7 +6,6 @@ module Bitcoin.Core.Regtest (
     runBitcoind,
     withBitcoind,
     peerWith,
-    withBitcoindCluster,
 
     -- * Funding
     oneBitcoin,

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
@@ -36,6 +36,7 @@ module Bitcoin.Core.Regtest (
     v21_0,
     v21_1,
     v22_0,
+    v23_0,
 ) where
 
 import Bitcoin.Core.Regtest.Framework

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -38,6 +38,7 @@ module Bitcoin.Core.Regtest.Framework (
     v21_0,
     v21_1,
     v22_0,
+    v23_0,
 ) where
 
 import Control.Concurrent (threadDelay)
@@ -334,10 +335,11 @@ textAddrs = addrToText' <$> addrs
 textAddr0, textAddr1, textAddr2 :: Text
 textAddr0 : textAddr1 : textAddr2 : _ = textAddrs
 
-v19_1, v20_0, v20_1, v21_0, v21_1, v22_0 :: Version
+v19_1, v20_0, v20_1, v21_0, v21_1, v22_0, v23_0 :: Version
 v19_1 = (0, 19, 1)
 v20_0 = (0, 20, 0)
 v20_1 = (0, 20, 1)
 v21_0 = (0, 21, 0)
 v21_1 = (0, 21, 1)
 v22_0 = (22, 0, 0)
+v23_0 = (23, 0, 0)

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
@@ -24,7 +24,7 @@ testGenerator :: Manager -> TestTree
 testGenerator mgr = testCaseSteps "generateWithTransactions" $ \step ->
     withBitcoind 8459 $ \nodeHandle -> do
         step "Generate some blocks"
-        h <- async $ generateWithTransactions mgr nodeHandle 1 (pure Nothing) (const 20)
+        h <- async $ generateWithTransactions mgr nodeHandle 1 Nothing (const 20)
         link h
 
         runBitcoind mgr nodeHandle $ waitForBlocks 120

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
@@ -22,7 +22,7 @@ import Test.Tasty.HUnit (testCaseSteps, (@?=))
 
 testGenerator :: Manager -> TestTree
 testGenerator mgr = testCaseSteps "generateWithTransactions" $ \step ->
-    withBitcoind 8459 $ \nodeHandle -> do
+    withBitcoind 8459 Nothing $ \nodeHandle -> do
         step "Generate some blocks"
         h <- async $ generateWithTransactions mgr nodeHandle 1 Nothing (const 20)
         link h

--- a/bitcoind-regtest/test/Main.hs
+++ b/bitcoind-regtest/test/Main.hs
@@ -13,7 +13,7 @@ import Bitcoin.Core.Test.PSBT (psbtRPC)
 import Bitcoin.Core.Test.Wallet (walletRPC)
 
 main :: IO ()
-main = withBitcoind 8449 $ \nodeHandle -> do
+main = withBitcoind 8449 Nothing $ \nodeHandle -> do
     threadDelay 1_000_000
     mgr <- newManager defaultManagerSettings
     defaultMain $

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -32,7 +32,7 @@ library
 
     build-depends:
           aeson >=2.0 && <2.1
-        , base >=4.12 && <4.16
+        , base >=4.12 && <4.17
         , base64 ^>=0.4
         , bytestring >=0.10 && <0.12
         , bitcoin-compact-filters ^>=0.1
@@ -41,12 +41,12 @@ library
         , haskoin-core >=0.17.1 && <0.22
         , http-client >=0.6 && <0.8
         , http-types ^>=0.12
-        , mtl ^>=2.2
+        , mtl >=2.2 && <2.4
         , scientific ^>=0.3
         , servant >=0.15 && <0.20
         , servant-client >=0.15 && <0.20
         , servant-jsonrpc-client >=1.0 && <1.2
-        , text ^>=1.2
+        , text >=1.2 && <2.1
         , time >=1.8 && <1.14
         , transformers >=0.5 && <0.7
 

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -163,8 +163,8 @@ import Bitcoin.Core.RPC.Network
 import Bitcoin.Core.RPC.Responses
 import Bitcoin.Core.RPC.Transactions
 import Bitcoin.Core.RPC.Wallet
-import Control.Monad.State.Strict (evalStateT, get, put, runStateT)
 import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict (evalStateT, get, put, runStateT)
 import Data.Aeson (Value)
 import qualified Data.Aeson as Ae
 import Network.HTTP.Types (statusCode)

--- a/bitcoind-rpc/src/Servant/Bitcoind.hs
+++ b/bitcoind-rpc/src/Servant/Bitcoind.hs
@@ -38,10 +38,10 @@ module Servant.Bitcoind (
 
 import Control.Exception (Exception)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.State.Strict (StateT, get)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT (..))
 import Control.Monad.Trans.Reader (ReaderT (..))
+import Control.Monad.Trans.State.Strict (StateT, get)
 import Data.Aeson (
     FromJSON (..),
     ToJSON (..),

--- a/nix/bitcoind-versions.nix
+++ b/nix/bitcoind-versions.nix
@@ -28,4 +28,9 @@
     url = "https://bitcoincore.org/bin/bitcoin-core-22.0/bitcoin-22.0-x86_64-linux-gnu.tar.gz";
     sha256 = "08l18bihda64bka4lhv046kdcjgwwngwws6v08lnrkp8j0l2l2rk";
   };
+
+  v23-0 = builtins.fetchTarball {
+    url = "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-x86_64-linux-gnu.tar.gz";
+    sha256 = "01hf9h88sw06ppsx2pxshw6a4bd1j1yg4kgjrxdcr54gmwk891kn";
+  };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -4,8 +4,9 @@ let bitcoindVersions = import ./bitcoind-versions.nix;
     mkBitcoindShell = bitcoindVersion:
       pkgs.mkShell {
         buildInputs = [
-          pkgs.secp256k1
           pkgs.gmp
+          pkgs.ncurses
+          pkgs.secp256k1
           pkgs.zlib
         ];
 
@@ -35,4 +36,5 @@ in
   v0-21-0 = mkBitcoindShell bitcoindVersions.v0-21-0;
   v0-21-1 = mkBitcoindShell bitcoindVersions.v0-21-1;
   v22-0 = mkBitcoindShell bitcoindVersions.v22-0;
+  v23-0 = mkBitcoindShell bitcoindVersions.v23-0;
 }


### PR DESCRIPTION
This change refactors the autominer to be much more performant.  It also makes it so that the program can resume from previous runs without mining 100 blocks, if it peers with a node that peered with the original instance.  This also makes it convenient to launch nodes from arbitrary data directories.  Users can use this to create test setups where their regtest network survives restarts.