### PR TITLE
Handle negative amounts in gettransaction amount

### DIFF
--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
@@ -972,8 +972,8 @@ instance FromJSON GetTxOutputDetails where
 
 -- | @since 0.3.0.0
 data GetTransactionResponse = GetTransactionResponse
-    { getTxAmount :: Word64
-    -- ^ The amount in sats
+    { getTxAmount :: Integer
+    -- ^ The amount in sats (could be negative when the transaction is a net spend)
     , getTxFee :: Maybe Word64
     -- ^ The fee in sats (for "send" transactions)
     , getTxConfs :: Int

--- a/bitcoind-rpc/src/Data/Aeson/Utils.hs
+++ b/bitcoind-rpc/src/Data/Aeson/Utils.hs
@@ -55,7 +55,7 @@ utcTime :: Word64 -> UTCTime
 utcTime = posixSecondsToUTCTime . fromIntegral
 
 -- | Convert BTC to Satoshis
-toSatoshis :: Scientific -> Word64
+toSatoshis :: Integral a => Scientific -> a
 toSatoshis = floor . (* satsPerBTC)
 
 satsPerBTC :: Num a => a


### PR DESCRIPTION
In regtest at least, calling `gettransaction` on a TX with no confirmations
(mempool), yields a negative amount, in several other places we use `abs` but
we were not doing that here.

Without this a negative amount (e.g. `-1.9999391`) could be seen and since we use `Word64` for holding such values it ends up underflowing showing as:

```haskell
GetTransactionResponse
    { getTxAmount = 18446744073509557706
    ...
    }
```