### PR TITLE
Update dependencies to support GHC 9.2.7 and 9.4.4

### DIFF
--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -16,7 +16,7 @@ common core
     ghc-options:      -Wall -fno-warn-unused-do-bind
     build-depends:
           async >=2.0 && <2.3
-        , base >=4.12 && <4.17
+        , base >=4.12 && <4.18
         , base64 ^>=0.4
         , bitcoind-rpc ^>=0.3
         , bytestring >=0.10 && <0.12

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Bitcoin.Core.Regtest.Framework (
     -- * Run an ephemeral regtest node

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Bitcoin.Core.Regtest.Generator (
     Funding (..),

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Bitcoin.Core.Test.Misc (
     miscRPC,

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -31,8 +31,8 @@ library
         Servant.Bitcoind
 
     build-depends:
-          aeson >=2.0 && <2.1
-        , base >=4.12 && <4.17
+          aeson >=2.0 && <2.2
+        , base >=4.12 && <4.18
         , base64 ^>=0.4
         , bytestring >=0.10 && <0.12
         , bitcoin-compact-filters ^>=0.1


### PR DESCRIPTION
It also addresses some warnings wrt uni-patterns in `bitcoind-regtest` whereas
some others I just disabled the warning as they really seem a non-issue.