### PR TITLE
Add `difficulty` field to the block header

### DIFF
--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Generator.hs
@@ -7,6 +7,7 @@ module Bitcoin.Core.Test.Generator (
 import Bitcoin.Core.RPC (BitcoindClient)
 import qualified Bitcoin.Core.RPC as RPC
 import Bitcoin.Core.Regtest (
+    GeneratorConfig (..),
     generateWithTransactions,
     runBitcoind,
     withBitcoind,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -141,6 +141,7 @@ data BlockHeader = BlockHeader
     , blockHeaderTime :: UTCTime
     , blockHeaderMedianTime :: UTCTime
     , blockHeaderNonce :: Word64
+    , blockHeaderDifficulty :: Scientific
     , blockHeaderTxCount :: Int
     , blockHeaderPrevHash :: Maybe Hash256
     , blockHeaderNextHash :: Maybe Hash256
@@ -156,6 +157,7 @@ instance FromJSON BlockHeader where
             <*> (utcTime <$> o .: "time")
             <*> (utcTime <$> o .: "mediantime")
             <*> o .: "nonce"
+            <*> o .: "difficulty"
             <*> o .: "nTx"
             <*> (o .:? "previousblockhash" >>= traverse parseFromHex)
             <*> (o .:? "nextblockhash" >>= traverse parseFromHex)

--- a/cabal.project
+++ b/cabal.project
@@ -18,3 +18,7 @@ source-repository-package
   type: git
   location: https://github.com/bitnomial/bitcoin-compact-filters
   tag: f161d97e40c82b2256ef661cb5c9d0bd64f1e05d
+
+constraints:
+  -- haskoin-core-0.21.2 needs
+  base16 < 1


### PR DESCRIPTION
This is another field that is exposed in the response of `getblockheader` RPC
call but it was missing from our `BlockHeader` data type.

This also adds a constraint on `base16` that helps cabal resolve dependencies
and make the project build.