### PR TITLE
Update servant version constraints

### DIFF
--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -25,8 +25,8 @@ common core
         , haskoin-core >=0.15 && <0.22
         , http-client >=0.6 && <0.8
         , process ^>=1.6
-        , servant >=0.19 && <0.20
-        , servant-client >=0.19 && <0.20
+        , servant >=0.19 && <0.21
+        , servant-client >=0.19.1 && <0.21
         , temporary ^>=1.3
         , text >=1.2 && <2.1
 

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -43,8 +43,8 @@ library
         , http-types ^>=0.12
         , mtl >=2.2 && <2.4
         , scientific ^>=0.3
-        , servant >=0.19 && <0.20
-        , servant-client >=0.19 && <0.20
+        , servant >=0.19 && <0.21
+        , servant-client >=0.19.1 && <0.21
         , servant-jsonrpc-client >=1.0 && <1.2
         , text >=1.2 && <2.1
         , time >=1.8 && <1.14

--- a/cabal.project
+++ b/cabal.project
@@ -10,14 +10,16 @@ package bitcoind-regtest
 
 source-repository-package
   type: git
-  location: https://github.com/haskell-servant/servant
-  subdir: servant-client
-  tag: v0.19.1
+  location: https://github.com/bitnomial/bitcoin-compact-filters
+  tag: 2ae18e7c7b66f1cfe60529645fce0c9b6536e986
 
 source-repository-package
   type: git
-  location: https://github.com/bitnomial/bitcoin-compact-filters
-  tag: f161d97e40c82b2256ef661cb5c9d0bd64f1e05d
+  location: https://github.com/bitnomial/servant-jsonrpc
+  tag: 938b39d0d0d115f1fceb6b5f5125319d19f82c5f
+  subdir:
+    servant-jsonrpc
+    servant-jsonrpc-client
 
 constraints:
   -- haskoin-core-0.21.2 needs


### PR DESCRIPTION
I also removed the pin on `servant-client-0.19.1` using v0.20 seems to work just fine. This allows downstream users find build plan when they are on `servant-0.20`.