### PR TITLE
Fix underflow in `total_out` when parsing blockstats

### DIFF
--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -38,6 +38,7 @@ import Data.Aeson (
     (.:?),
  )
 import Data.Aeson.Types (Parser)
+import Data.Int (Int64)
 import Data.Proxy (Proxy (..))
 import Data.Scientific (Scientific)
 import Data.Serialize (Serialize)
@@ -85,7 +86,7 @@ data BlockStats = BlockStats
     , blockStastSegwitWeight :: Word32
     , blockStatsSegwitCount :: Word32
     , blockStatsTime :: UTCTime
-    , blockStatsTotalOut :: Word32
+    , blockStatsTotalOut :: Int64
     , blockStatsTotalSize :: Word32
     , blockStatsTotalWeight :: Word32
     , blockStatsTotalFee :: Word32

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -44,7 +44,7 @@ import Data.Serialize (Serialize)
 import Data.Text (Text)
 import Data.Time (NominalDiffTime, UTCTime)
 import Data.Word (Word16, Word32, Word64)
-import Haskoin.Block (Block, BlockHash, BlockHeight)
+import Haskoin.Block (Block, BlockHash, BlockHeight, hexToBlockHash)
 import Haskoin.Crypto (Hash256)
 import Haskoin.Transaction (TxHash)
 import Servant.API ((:<|>) (..))
@@ -143,8 +143,8 @@ data BlockHeader = BlockHeader
     , blockHeaderNonce :: Word64
     , blockHeaderDifficulty :: Scientific
     , blockHeaderTxCount :: Int
-    , blockHeaderPrevHash :: Maybe Hash256
-    , blockHeaderNextHash :: Maybe Hash256
+    , blockHeaderPrevHash :: Maybe BlockHash
+    , blockHeaderNextHash :: Maybe BlockHash
     }
 
 instance FromJSON BlockHeader where
@@ -159,8 +159,10 @@ instance FromJSON BlockHeader where
             <*> o .: "nonce"
             <*> o .: "difficulty"
             <*> o .: "nTx"
-            <*> (o .:? "previousblockhash" >>= traverse parseFromHex)
-            <*> (o .:? "nextblockhash" >>= traverse parseFromHex)
+            <*> (o .:? "previousblockhash" >>= traverse parseBlockHash)
+            <*> (o .:? "nextblockhash" >>= traverse parseBlockHash)
+      where
+        parseBlockHash = maybe (fail "Invalid hex in block hash") pure . hexToBlockHash
 
 parseFromHex :: Serialize a => Text -> Parser a
 parseFromHex = either fail return . decodeFromHex


### PR DESCRIPTION
In bitcoin-core the the type of `total_out` is `int64_t`, the type was updated
to match that, by having a `Word32` here I was observing an underflow when
attempting to parse the response of the `getblockstats` RPC command.

Additionally there's also a change to parse block hash in block header as
`BlockHash` values. When parsing block hashes out of the `getblockheader`
response it makes more sense to parse `previousblockhash` and `nextblockhash`
as actual `BlockHash` values rather than plain SHA256 hashes.