### PR TITLE
Pin and format using the default fourmolu configuration

### DIFF
--- a/bitcoind-regtest/Setup.hs
+++ b/bitcoind-regtest/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -317,11 +317,11 @@ data FloodState = FloodState
     }
     deriving (Eq, Show)
 
-pushFloodRoot :: Monad m => FloodRootPoint -> StateT FloodState m ()
+pushFloodRoot :: (Monad m) => FloodRootPoint -> StateT FloodState m ()
 pushFloodRoot rootPoint = modify' $ \floodState ->
     floodState{floodRoots = rootPoint : floodRoots floodState}
 
-flushFloodRoots :: Monad m => Int -> StateT FloodState m [FloodRootPoint]
+flushFloodRoots :: (Monad m) => Int -> StateT FloodState m [FloodRootPoint]
 flushFloodRoots n = do
     (flushedRoots, remainingRoots) <- splitAt n <$> gets floodRoots
     modify' $ \floodState -> floodState{floodRoots = remainingRoots}
@@ -359,7 +359,7 @@ getFloodBalance = gets $ sum . fmap floodAmount . floodRoots
 getBalance :: BitcoindClient Word64
 getBalance = RPC.balanceDetailsTrusted . RPC.balancesMine <$> RPC.getBalances
 
-getSeriesCount :: Monad m => StateT FloodState m Int
+getSeriesCount :: (Monad m) => StateT FloodState m Int
 getSeriesCount = gets $ length . floodSeries
 
 type TxSeries = [Tx]
@@ -383,7 +383,7 @@ buildSeries nOutputs feeRate floodRootPoint =
 flood :: StateT FloodState BitcoindClient [TxHash]
 flood = advance >>= lift . traverse (`RPC.sendTransaction` Nothing)
 
-advance :: Monad m => StateT FloodState m [Tx]
+advance :: (Monad m) => StateT FloodState m [Tx]
 advance = state . asFloodStateUpdate $ peelFirst &&& dropFirst
   where
     peelFirst = mapMaybe (fmap fst . uncons)
@@ -536,7 +536,7 @@ spendEasy ix prevOutput =
 the equal entries using the combining function.
 -}
 zipMerge ::
-    Ord k =>
+    (Ord k) =>
     (a -> b -> c) ->
     (a -> k) ->
     (b -> k) ->

--- a/bitcoind-rpc/Setup.hs
+++ b/bitcoind-rpc/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -165,7 +165,7 @@ instance FromJSON BlockHeader where
       where
         parseBlockHash = maybe (fail "Invalid hex in block hash") pure . hexToBlockHash
 
-parseFromHex :: Serialize a => Text -> Parser a
+parseFromHex :: (Serialize a) => Text -> Parser a
 parseFromHex = either fail return . decodeFromHex
 
 data ChainTipStatus = Invalid | HeadersOnly | ValidHeaders | ValidFork | Active

--- a/bitcoind-rpc/src/Data/Aeson/Utils.hs
+++ b/bitcoind-rpc/src/Data/Aeson/Utils.hs
@@ -47,7 +47,7 @@ import Haskoin.Util (decodeHex, encodeHex)
 partialObject :: [Maybe Pair] -> Value
 partialObject = object . catMaybes
 
-(.=?) :: ToJSON a => Key -> Maybe a -> Maybe Pair
+(.=?) :: (ToJSON a) => Key -> Maybe a -> Maybe Pair
 k .=? mv = (k .=) <$> mv
 
 -- | Helper function for decoding POSIX timestamps
@@ -55,10 +55,10 @@ utcTime :: Word64 -> UTCTime
 utcTime = posixSecondsToUTCTime . fromIntegral
 
 -- | Convert BTC to Satoshis
-toSatoshis :: Integral a => Scientific -> a
+toSatoshis :: (Integral a) => Scientific -> a
 toSatoshis = floor . (* satsPerBTC)
 
-satsPerBTC :: Num a => a
+satsPerBTC :: (Num a) => a
 satsPerBTC = 1_0000_0000
 
 -- | Convert sats to BTC
@@ -70,25 +70,25 @@ rangeToJSON (n, Just m) = toJSON [n, m]
 rangeToJSON (n, _) = toJSON n
 
 -- | Read a serializable from a hex string
-decodeFromHex :: Serialize a => Text -> Either String a
+decodeFromHex :: (Serialize a) => Text -> Either String a
 decodeFromHex = maybe (Left "Invalid hex") Right . decodeHex >=> decode
 
 newtype HexEncoded a = HexEncoded {unHexEncoded :: a} deriving (Eq, Show)
 
-instance Serialize a => FromJSON (HexEncoded a) where
+instance (Serialize a) => FromJSON (HexEncoded a) where
     parseJSON = withText "HexEncoded" $ either fail (return . HexEncoded) . decodeFromHex
 
-instance Serialize a => ToJSON (HexEncoded a) where
+instance (Serialize a) => ToJSON (HexEncoded a) where
     toJSON = toJSON . encodeHex . S.encode . unHexEncoded
 
 newtype Base64Encoded a = Base64Encoded {unBase64Encoded :: a} deriving (Eq, Show)
 
-instance Serialize a => FromJSON (Base64Encoded a) where
+instance (Serialize a) => FromJSON (Base64Encoded a) where
     parseJSON =
         withText "Base64Encoded" $
             either fail (pure . Base64Encoded)
                 . (S.decode <=< first Text.unpack . decodeBase64)
                 . encodeUtf8
 
-instance Serialize a => ToJSON (Base64Encoded a) where
+instance (Serialize a) => ToJSON (Base64Encoded a) where
     toJSON = toJSON . encodeBase64 . S.encode . unBase64Encoded

--- a/bitcoind-rpc/src/Servant/Bitcoind.hs
+++ b/bitcoind-rpc/src/Servant/Bitcoind.hs
@@ -121,7 +121,7 @@ instance HasDefault EmptyList [a] where getDefault _ = []
 
 data DefZero
 
-instance Num a => HasDefault DefZero a where getDefault _ = 0
+instance (Num a) => HasDefault DefZero a where getDefault _ = 0
 
 class HasBitcoindClient x where
     type TheBitcoindClient x :: Type
@@ -182,7 +182,7 @@ newtype BitcoindClient a = BitcoindClient
     }
     deriving (Functor, Applicative, Monad, MonadIO)
 
-getWalletPath :: Monad m => StateT (Maybe WalletName) m [Text]
+getWalletPath :: (Monad m) => StateT (Maybe WalletName) m [Text]
 getWalletPath = maybe mempty toPath <$> get
   where
     toPath name = ["wallet", name]
@@ -218,7 +218,7 @@ instance Rewrite CX where
             Result{} -> Left $ RpcException "Expecting ack; got result"
 
 -- | Endpoints which simply return a value
-instance FromJSON r => Rewrite (C r) where
+instance (FromJSON r) => Rewrite (C r) where
     type RewriteFrom (C r) = NakedClient
     type RewriteTo (C r) = BitcoindClient r
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,51 @@
+# Number of spaces per indentation step
+indentation: 4
+
+# Max line length for automatic line breaking
+column-limit: none
+
+# Styling of arrows in type signatures (choices: trailing, leading, or leading-args)
+function-arrows: trailing
+
+# How to place commas in multi-line lists, records, etc. (choices: leading or trailing)
+comma-style: leading
+
+# Styling of import/export lists (choices: leading, trailing, or diff-friendly)
+import-export-style: diff-friendly
+
+# Whether to full-indent or half-indent 'where' bindings past the preceding body
+indent-wheres: false
+
+# Whether to leave a space before an opening record brace
+record-brace-space: false
+
+# Number of spaces between top-level declarations
+newlines-between-decls: 1
+
+# How to print Haddock comments (choices: single-line, multi-line, or multi-line-compact)
+haddock-style: multi-line
+
+# How to print module docstring
+haddock-style-module: null
+
+# Styling of let blocks (choices: auto, inline, newline, or mixed)
+let-style: auto
+
+# How to align the 'in' keyword with respect to the 'let' keyword (choices: left-align, right-align, or no-space)
+in-style: right-align
+
+# Whether to put parentheses around a single constraint (choices: auto, always, or never)
+single-constraint-parens: always
+
+# Output Unicode syntax (choices: detect, always, or never)
+unicode: never
+
+# Give the programmer more choice on where to insert blank lines
+respectful: true
+
+# Fixity information for operators
+fixities: []
+
+# Module reexports Fourmolu should know about
+reexports: []
+


### PR DESCRIPTION
This adds a `fourmolu.yaml` and formats the code accordingly, it was generated using:

``` console
$ fourmolu --print-defaults > fourmolu.yaml
```

The motivation being that we have this in the `README.md`:

> Please use `ormolu` or `fourmolu` (with the default configuration) for code formatting.

However, for users that use a different configuration at the user level
configuration this is inconvenient since there's not an easy way of using the
default configuration.

Also it might be that the default configuration tends to drift since the existing code was out of style already, this will help prevent such thing in the future assuming contributors follow it.