### PR TITLE
Support verbosity level 0 and 2 in `getblock` RPC command

### DIFF
--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -291,7 +291,9 @@ generateEnoughBlocks vTarget = go ([], 0, 0 :: Int)
 generate :: BitcoindClient (OutPoint, Word64)
 generate =
     fmap (processCoinbase . head . blockTxns) $
-        RPC.generateToAddress 1 textAddr0 Nothing >>= RPC.getBlock' . head
+        RPC.generateToAddress 1 textAddr0 Nothing >>= getBlock . head
+  where
+    getBlock h = RPC.getBlockBlock =<< RPC.getBlock h (Just 0)
 
 processCoinbase :: Tx -> (OutPoint, Word64)
 processCoinbase tx0 = (OutPoint (txHash tx0) 0, outValue . head $ txOut tx0)

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -291,7 +291,7 @@ generateEnoughBlocks vTarget = go ([], 0, 0 :: Int)
 generate :: BitcoindClient (OutPoint, Word64)
 generate =
     fmap (processCoinbase . head . blockTxns) $
-        RPC.generateToAddress 1 textAddr0 Nothing >>= RPC.getBlock . head
+        RPC.generateToAddress 1 textAddr0 Nothing >>= RPC.getBlock' . head
 
 processCoinbase :: Tx -> (OutPoint, Word64)
 processCoinbase tx0 = (OutPoint (txHash tx0) 0, outValue . head $ txOut tx0)

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -293,7 +293,7 @@ generate =
     fmap (processCoinbase . head . blockTxns) $
         RPC.generateToAddress 1 textAddr0 Nothing >>= getBlock . head
   where
-    getBlock h = RPC.getBlockBlock =<< RPC.getBlock h (Just 0)
+    getBlock h = RPC.getBlockBlock <$> RPC.getBlock h (Just 0)
 
 processCoinbase :: Tx -> (OutPoint, Word64)
 processCoinbase tx0 = (OutPoint (txHash tx0) 0, outValue . head $ txOut tx0)

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -461,7 +461,8 @@ sweep = do
     fmap toFloodRootPoint . Set.toList <$> foldM onBlockHeight mempty [0 .. currentHeight]
   where
     onBlockHeight !utxos n = updateUtxoSet utxos <$> getSpentUnspent n
-    getSpentUnspent = RPC.getBlockHash >=> fmap onBlock . RPC.getBlock'
+    getSpentUnspent = RPC.getBlockHash >=> fmap onBlock . getBlock
+    getBlock h = RPC.getBlockBlock =<< RPC.getBlock h (Just 0)
     onBlock = finalizeBlockDelta . foldl' onTransaction (BlockDelta mempty mempty) . H.blockTxns
     onTransaction delta tx =
         BlockDelta

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -462,7 +462,7 @@ sweep = do
   where
     onBlockHeight !utxos n = updateUtxoSet utxos <$> getSpentUnspent n
     getSpentUnspent = RPC.getBlockHash >=> fmap onBlock . getBlock
-    getBlock h = RPC.getBlockBlock =<< RPC.getBlock h (Just 0)
+    getBlock h = RPC.getBlockBlock <$> RPC.getBlock h (Just 0)
     onBlock = finalizeBlockDelta . foldl' onTransaction (BlockDelta mempty mempty) . H.blockTxns
     onTransaction delta tx =
         BlockDelta

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Generator.hs
@@ -461,7 +461,7 @@ sweep = do
     fmap toFloodRootPoint . Set.toList <$> foldM onBlockHeight mempty [0 .. currentHeight]
   where
     onBlockHeight !utxos n = updateUtxoSet utxos <$> getSpentUnspent n
-    getSpentUnspent = RPC.getBlockHash >=> fmap onBlock . RPC.getBlock
+    getSpentUnspent = RPC.getBlockHash >=> fmap onBlock . RPC.getBlock'
     onBlock = finalizeBlockDelta . foldl' onTransaction (BlockDelta mempty mempty) . H.blockTxns
     onTransaction delta tx =
         BlockDelta

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -81,6 +81,8 @@ Just addrText = addrToText btcTest addr
 
 testBlock :: BitcoindClient Block
 testBlock = getBestBlockHash >>= getBlock'
+  where
+    getBlock' h = getBlockBlock =<< getBlock h (Just 0)
 
 testBlockFilter :: BitcoindClient CompactFilter
 testBlockFilter = getBestBlockHash >>= getBlockFilter
@@ -94,6 +96,8 @@ testBlockStats = getBestBlockHash >>= getBlockStats
 testGetTransaction :: BitcoindClient Tx
 testGetTransaction =
     getBestBlockHash >>= getBlock' >>= (`getRawTransaction` Nothing) . txHash . head . blockTxns
+  where
+    getBlock' h = getBlockBlock =<< getBlock h (Just 0)
 
 testSendTransaction :: BitcoindClient TxHash
 testSendTransaction = do

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -80,7 +80,7 @@ addrText :: Text
 Just addrText = addrToText btcTest addr
 
 testBlock :: BitcoindClient Block
-testBlock = getBestBlockHash >>= getBlock
+testBlock = getBestBlockHash >>= getBlock'
 
 testBlockFilter :: BitcoindClient CompactFilter
 testBlockFilter = getBestBlockHash >>= getBlockFilter
@@ -93,7 +93,7 @@ testBlockStats = getBestBlockHash >>= getBlockStats
 
 testGetTransaction :: BitcoindClient Tx
 testGetTransaction =
-    getBestBlockHash >>= getBlock >>= (`getRawTransaction` Nothing) . txHash . head . blockTxns
+    getBestBlockHash >>= getBlock' >>= (`getRawTransaction` Nothing) . txHash . head . blockTxns
 
 testSendTransaction :: BitcoindClient TxHash
 testSendTransaction = do

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -82,7 +82,7 @@ Just addrText = addrToText btcTest addr
 testBlock :: BitcoindClient Block
 testBlock = getBestBlockHash >>= getBlock'
   where
-    getBlock' h = getBlockBlock =<< getBlock h (Just 0)
+    getBlock' h = getBlockBlock <$> getBlock h (Just 0)
 
 testBlockFilter :: BitcoindClient CompactFilter
 testBlockFilter = getBestBlockHash >>= getBlockFilter
@@ -97,7 +97,7 @@ testGetTransaction :: BitcoindClient Tx
 testGetTransaction =
     getBestBlockHash >>= getBlock' >>= (`getRawTransaction` Nothing) . txHash . head . blockTxns
   where
-    getBlock' h = getBlockBlock =<< getBlock h (Just 0)
+    getBlock' h = getBlockBlock <$> getBlock h (Just 0)
 
 testSendTransaction :: BitcoindClient TxHash
 testSendTransaction = do

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Bitcoin.Core.Test.Utils (
     testRpc,
     bitcoindTest,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -36,7 +36,6 @@ module Bitcoin.Core.RPC (
 
     -- * Blocks
     getBlock,
-    getBlock',
     getBlockFilter,
     getBlockHeader,
     getBlockBlock,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -36,8 +36,10 @@ module Bitcoin.Core.RPC (
 
     -- * Blocks
     getBlock,
+    getBlock',
     getBlockFilter,
     getBlockHeader,
+    getBlockBlock,
     getBlockHash,
     getBlockCount,
     getDifficulty,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -56,8 +56,8 @@ import Data.Text (Text)
 import Data.Time (NominalDiffTime, UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word16, Word32, Word64)
+import qualified Haskoin as H
 import Haskoin.Block (Block (..), BlockHash, BlockHeight, hexToBlockHash)
-import qualified Haskoin.Block as Haskoin
 import Haskoin.Crypto (Hash256)
 import Haskoin.Transaction (Tx, TxHash)
 import Servant.API ((:<|>) (..))
@@ -382,13 +382,13 @@ getBlockBlock = \case
     GetBlockV0 block -> block
     GetBlockV2 response ->
         Block
-            ( Haskoin.BlockHeader
-                { Haskoin.blockVersion = getBlockV2Version response
-                , Haskoin.merkleRoot = getBlockV2MerkleRoot response
-                , Haskoin.blockBits = getBlockV2Bits response
-                , Haskoin.bhNonce = getBlockV2Nonce response
-                , Haskoin.blockTimestamp = round . utcTimeToPOSIXSeconds $ getBlockV2Time response
-                , Haskoin.prevBlock =
+            ( H.BlockHeader
+                { H.blockVersion = getBlockV2Version response
+                , H.merkleRoot = getBlockV2MerkleRoot response
+                , H.blockBits = getBlockV2Bits response
+                , H.bhNonce = getBlockV2Nonce response
+                , H.blockTimestamp = round . utcTimeToPOSIXSeconds $ getBlockV2Time response
+                , H.prevBlock =
                     fromMaybe (error "no previous block hash on genesis") $
                         getBlockV2PreviousBlockHash response
                 }

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -374,8 +374,8 @@ getBlockStats :: BlockHash -> BitcoindClient BlockStats
 getBlockStats h = getBlockStats' h Nothing
 
 {- | Produce the block corresponding to the given 'BlockHash' if it exists. Note
-that a 'DecodingError' will be thrown if the response does not correspond to a
-hex serialized block.
+that this won't work for the Genesis block since to construct a 'BlockHeader' a
+hash to a previous block is necessary.
 -}
 getBlockBlock :: GetBlockResponse -> Block
 getBlockBlock = \case


### PR DESCRIPTION
The verbosity level when calling `getblock` RPC command wasn't configurable,
now it is, but only 0 and 2 are supported which should cover most of the
use-cases. Specifically this change was made to access fees per transaction in
a specified block.