### PR TITLE
Expose `GetBlockResponse` constructors and eliminator

### DIFF
--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -40,6 +40,7 @@ module Bitcoin.Core.RPC (
     getBlockHeader,
     getBlockBlock,
     getBlockHash,
+    getBlockResponse,
     getBlockCount,
     getDifficulty,
     getBestBlockHash,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Responses.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Responses.hs
@@ -16,6 +16,8 @@ module Bitcoin.Core.RPC.Responses (
     ChainTip (..),
     ChainTipStatus (..),
     ChainTxStats (..),
+    GetBlockResponse (..),
+    GetBlockV2Response (..),
 
     -- * Mempool
     MempoolInfo (..),


### PR DESCRIPTION
Downstream users will need this if they want to use a `GetBlockV2` response by
itself, or an easy way to extract something from a `GetBlockResponse`.

This is a followup on #20.