### PR TITLE
Support selective querying of stats for `getblockstats` + fix overflows

### DIFF
--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -91,7 +91,7 @@ testBlockHeader :: BitcoindClient BlockHeader
 testBlockHeader = getBestBlockHash >>= getBlockHeader
 
 testBlockStats :: BitcoindClient BlockStats
-testBlockStats = getBestBlockHash >>= getBlockStats
+testBlockStats = getBestBlockHash >>= \h -> getBlockStats h Nothing
 
 testGetTransaction :: BitcoindClient Tx
 testGetTransaction =

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -45,7 +45,6 @@ module Bitcoin.Core.RPC (
     getDifficulty,
     getBestBlockHash,
     getBlockStats,
-    getBlockStats',
     getChainTips,
     getChainTxStats,
 

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -44,6 +44,7 @@ module Bitcoin.Core.RPC (
     getBlockCount,
     getDifficulty,
     getBestBlockHash,
+    BlockStat (..),
     getBlockStats,
     getChainTips,
     getChainTxStats,

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC.hs
@@ -45,6 +45,7 @@ module Bitcoin.Core.RPC (
     getDifficulty,
     getBestBlockHash,
     getBlockStats,
+    getBlockStats',
     getChainTips,
     getChainTxStats,
 

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -21,7 +21,6 @@ module Bitcoin.Core.RPC.Blockchain (
     getBlockHeader,
     BlockStats (..),
     getBlockStats,
-    getBlockStats',
     ChainTip (..),
     ChainTipStatus (..),
     getChainTips,
@@ -155,6 +154,7 @@ data BlockHeader = BlockHeader
     , blockHeaderPrevHash :: Maybe BlockHash
     , blockHeaderNextHash :: Maybe BlockHash
     }
+    deriving (Eq, Show)
 
 instance FromJSON BlockHeader where
     parseJSON = withObject "BlockHeader" $ \o ->
@@ -337,7 +337,11 @@ getBlockFilter :: BlockHash -> BitcoindClient CompactFilter
 
 -- | Returns the header of the block corresponding to the given 'BlockHash'
 getBlockHeader :: BlockHash -> BitcoindClient BlockHeader
-getBlockStats' :: BlockHash -> Maybe [Text] -> BitcoindClient BlockStats
+
+{- | Compute per block statistics for a given window. All amounts are in
+ satoshis.  It won't work for some heights with pruning.
+-}
+getBlockStats :: BlockHash -> Maybe [Text] -> BitcoindClient BlockStats
 
 {- | Return information about all known tips in the block tree, including the
  main chain as well as orphaned branches.
@@ -367,7 +371,7 @@ getBestBlockHash
     :<|> getBlockFilter
     :<|> getBlockHash
     :<|> getBlockHeader
-    :<|> getBlockStats'
+    :<|> getBlockStats
     :<|> getChainTips
     :<|> getChainTxStats
     :<|> getDifficulty
@@ -376,12 +380,6 @@ getBestBlockHash
     :<|> getMempoolInfo
     :<|> getRawMempool =
         toBitcoindClient $ Proxy @BlockchainRpc
-
-{- | Compute per block statistics for a given window. All amounts are in
- satoshis.  It won't work for some heights with pruning.
--}
-getBlockStats :: BlockHash -> BitcoindClient BlockStats
-getBlockStats h = getBlockStats' h Nothing
 
 {- | Produce the block corresponding to the given 'BlockHash' if it exists. Note
 that this won't work for the Genesis block since to construct a 'BlockHeader' a

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -84,96 +84,96 @@ These are labels for the statistics accepted in the 'getblockstat' RPC command.
 -}
 data BlockStat
     = -- | Selects the average fee in the block statistic
-      AvgFee
+      StatAvgFee
     | -- | Selects the average feerate (in satoshis per virtual byte) statistic
-      AvgFeeRate
+      StatAvgFeeRate
     | -- | Selects the average transaction size statistic
-      AvgTxSize
+      StatAvgTxSize
     | -- | Selects the block hash (to check for potential reorgs)
-      BlockHash
+      StatBlockHash
     | -- | Selects feerates statistics at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per virtual byte)
-      FeeRatePercentiles
+      StatFeeRatePercentiles
     | -- | Selects the height of the block
-      Height
+      StatHeight
     | -- | Selects the number of inputs (excluding coinbase) statistic
-      Inputs
+      StatInputs
     | -- | Selects the maximum fee in the block statistic
-      MaxFee
+      StatMaxFee
     | -- | Selects the maximum feerate (in satoshis per virtual byte) statistic
-      MaxFeeRate
+      StatMaxFeeRate
     | -- | Selects the maximum transaction size statistic
-      MaxTxSize
+      StatMaxTxSize
     | -- | Selects the truncated median fee in the block statistic
-      MedianFee
+      StatMedianFee
     | -- | Selects the block median time past statistic
-      MedianTime
+      StatMedianTime
     | -- | Selects the truncated median transaction size statistic
-      MedianTxSize
+      StatMedianTxSize
     | -- | Selects the minimum fee in the block statistic
-      MinFee
+      StatMinFee
     | -- | Selects the minimum feerate (in satoshis per virtual byte) statistic
-      MinFeeRate
+      StatMinFeeRate
     | -- | Selects the minimum transaction size statistic
-      MinTxSize
+      StatMinTxSize
     | -- | Selects the number of outputs statistic
-      Outputs
+      StatOutputs
     | -- | Selects the block subsidy
-      Subsidy
+      StatSubsidy
     | -- | Selects the total size of all segwit transactions statistic
-      SegwitTotalSize
+      StatSegwitTotalSize
     | -- | Selects the total weight of all segwit transactions statistic
-      SegwitTotalWeight
+      StatSegwitTotalWeight
     | -- | Selects the number of segwit transactions statistic
-      SegwitTxs
+      StatSegwitTxs
     | -- | Selects the block time
-      Time
+      StatTime
     | -- | Selects the total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee]) statistic
-      TotalOut
+      StatTotalOut
     | -- | Selects the total size of all non-coinbase transactions statistic
-      TotalSize
+      StatTotalSize
     | -- | Selects the total weight of all non-coinbase transactions statistic
-      TotalWeight
+      StatTotalWeight
     | -- | Selects the fee total statistic
-      TotalFee
+      StatTotalFee
     | -- | Selects the number of transactions (including coinbase) statistic
-      Txs
+      StatTxs
     | -- | Selects the increase/decrease in the number of unspent outputs statistic
-      UtxoIncrease
+      StatUtxoIncrease
     | -- | Selects the increase/decrease in size for the utxo index (not discounting op_return and similar) statistic
-      UtxoSizeIncrease
+      StatUtxoSizeIncrease
     deriving (Eq, Show)
 
 instance ToJSON BlockStat where
     toJSON = \case
-        AvgFee -> "avgfee"
-        AvgFeeRate -> "avgfeerate"
-        AvgTxSize -> "avgtxsize"
-        BlockHash -> "blockhash"
-        FeeRatePercentiles -> "feerate_percentiles"
-        Height -> "height"
-        Inputs -> "ins"
-        MaxFee -> "maxfee"
-        MaxFeeRate -> "maxfeerate"
-        MaxTxSize -> "maxtxsize"
-        MedianFee -> "medianfee"
-        MedianTime -> "mediantime"
-        MedianTxSize -> "mediantxsize"
-        MinFee -> "minfee"
-        MinFeeRate -> "minfeerate"
-        MinTxSize -> "mintxsize"
-        Outputs -> "outs"
-        Subsidy -> "subsidy"
-        SegwitTotalSize -> "swtotal_size"
-        SegwitTotalWeight -> "swtotal_weight"
-        SegwitTxs -> "swtxs"
-        Time -> "time"
-        TotalOut -> "total_out"
-        TotalSize -> "total_size"
-        TotalWeight -> "total_weight"
-        TotalFee -> "totalfee"
-        Txs -> "txs"
-        UtxoIncrease -> "utxo_increase"
-        UtxoSizeIncrease -> "utxo_size_inc"
+        StatAvgFee -> "avgfee"
+        StatAvgFeeRate -> "avgfeerate"
+        StatAvgTxSize -> "avgtxsize"
+        StatBlockHash -> "blockhash"
+        StatFeeRatePercentiles -> "feerate_percentiles"
+        StatHeight -> "height"
+        StatInputs -> "ins"
+        StatMaxFee -> "maxfee"
+        StatMaxFeeRate -> "maxfeerate"
+        StatMaxTxSize -> "maxtxsize"
+        StatMedianFee -> "medianfee"
+        StatMedianTime -> "mediantime"
+        StatMedianTxSize -> "mediantxsize"
+        StatMinFee -> "minfee"
+        StatMinFeeRate -> "minfeerate"
+        StatMinTxSize -> "mintxsize"
+        StatOutputs -> "outs"
+        StatSubsidy -> "subsidy"
+        StatSegwitTotalSize -> "swtotal_size"
+        StatSegwitTotalWeight -> "swtotal_weight"
+        StatSegwitTxs -> "swtxs"
+        StatTime -> "time"
+        StatTotalOut -> "total_out"
+        StatTotalSize -> "total_size"
+        StatTotalWeight -> "total_weight"
+        StatTotalFee -> "totalfee"
+        StatTxs -> "txs"
+        StatUtxoIncrease -> "utxo_increase"
+        StatUtxoSizeIncrease -> "utxo_size_inc"
 
 data BlockStats = BlockStats
     { blockStatsAvgFee :: Maybe Double

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -21,6 +21,7 @@ module Bitcoin.Core.RPC.Blockchain (
     getBlockHeader,
     BlockStats (..),
     getBlockStats,
+    getBlockStats',
     ChainTip (..),
     ChainTipStatus (..),
     getChainTips,
@@ -77,58 +78,58 @@ import Servant.Bitcoind (
  )
 
 data BlockStats = BlockStats
-    { blockStatsAvgFee :: Double
-    , blockStatsAvgFeeRate :: Word32
-    , blockStatsAvgTxSize :: Word32
-    , blockStatsBlockHash :: BlockHash
-    , blockStatsFeeRatePercentiles :: [Word32]
-    , blockStatsHeight :: BlockHeight
-    , blockStatsIns :: Word32
-    , blockStatsMaxFee :: Word32
-    , blockStatsMaxFeeRate :: Word32
-    , blockStatsMinTxSize :: Word32
-    , blockStatsOuts :: Word32
-    , blockStatsSubsidy :: Word64
-    , blockStatsSegwitSize :: Word32
-    , blockStastSegwitWeight :: Word32
-    , blockStatsSegwitCount :: Word32
-    , blockStatsTime :: UTCTime
-    , blockStatsTotalOut :: Int64
-    , blockStatsTotalSize :: Word32
-    , blockStatsTotalWeight :: Word32
-    , blockStatsTotalFee :: Word32
-    , blockStatsCount :: Word32
-    , blockStatsUtxoIncrease :: Int
-    , blockStatsUtxoSizeIncrease :: Int
+    { blockStatsAvgFee :: Maybe Double
+    , blockStatsAvgFeeRate :: Maybe Word32
+    , blockStatsAvgTxSize :: Maybe Word32
+    , blockStatsBlockHash :: Maybe BlockHash
+    , blockStatsFeeRatePercentiles :: Maybe [Word32]
+    , blockStatsHeight :: Maybe BlockHeight
+    , blockStatsIns :: Maybe Word32
+    , blockStatsMaxFee :: Maybe Word32
+    , blockStatsMaxFeeRate :: Maybe Word32
+    , blockStatsMinTxSize :: Maybe Word32
+    , blockStatsOuts :: Maybe Word32
+    , blockStatsSubsidy :: Maybe Word64
+    , blockStatsSegwitSize :: Maybe Word32
+    , blockStastSegwitWeight :: Maybe Word32
+    , blockStatsSegwitCount :: Maybe Word32
+    , blockStatsTime :: Maybe UTCTime
+    , blockStatsTotalOut :: Maybe Int64
+    , blockStatsTotalSize :: Maybe Word32
+    , blockStatsTotalWeight :: Maybe Word32
+    , blockStatsTotalFee :: Maybe Word32
+    , blockStatsCount :: Maybe Word32
+    , blockStatsUtxoIncrease :: Maybe Int
+    , blockStatsUtxoSizeIncrease :: Maybe Int
     }
     deriving (Eq, Show)
 
 instance FromJSON BlockStats where
     parseJSON = withObject "BlockStats" $ \o ->
         BlockStats
-            <$> o .: "avgfee"
-            <*> o .: "avgfeerate"
-            <*> o .: "avgtxsize"
-            <*> o .: "blockhash"
-            <*> o .: "feerate_percentiles"
-            <*> o .: "height"
-            <*> o .: "ins"
-            <*> o .: "maxfee"
-            <*> o .: "maxfeerate"
-            <*> o .: "mintxsize"
-            <*> o .: "outs"
-            <*> o .: "subsidy"
-            <*> o .: "swtotal_size"
-            <*> o .: "swtotal_weight"
-            <*> o .: "swtxs"
-            <*> (utcTime <$> o .: "time")
-            <*> o .: "total_out"
-            <*> o .: "total_size"
-            <*> o .: "total_weight"
-            <*> o .: "totalfee"
-            <*> o .: "txs"
-            <*> o .: "utxo_increase"
-            <*> o .: "utxo_size_inc"
+            <$> o .:? "avgfee"
+            <*> o .:? "avgfeerate"
+            <*> o .:? "avgtxsize"
+            <*> o .:? "blockhash"
+            <*> o .:? "feerate_percentiles"
+            <*> o .:? "height"
+            <*> o .:? "ins"
+            <*> o .:? "maxfee"
+            <*> o .:? "maxfeerate"
+            <*> o .:? "mintxsize"
+            <*> o .:? "outs"
+            <*> o .:? "subsidy"
+            <*> o .:? "swtotal_size"
+            <*> o .:? "swtotal_weight"
+            <*> o .:? "swtxs"
+            <*> (fmap utcTime <$> o .:? "time")
+            <*> o .:? "total_out"
+            <*> o .:? "total_size"
+            <*> o .:? "total_weight"
+            <*> o .:? "totalfee"
+            <*> o .:? "txs"
+            <*> o .:? "utxo_increase"
+            <*> o .:? "utxo_size_inc"
 
 data CompactFilter = CompactFilter
     { filterHeader :: BlockFilterHeader

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -85,7 +85,7 @@ data BlockStats = BlockStats
     , blockStatsFeeRatePercentiles :: Maybe [Word32]
     , blockStatsHeight :: Maybe BlockHeight
     , blockStatsIns :: Maybe Word32
-    , blockStatsMaxFee :: Maybe Word32
+    , blockStatsMaxFee :: Maybe Word64
     , blockStatsMaxFeeRate :: Maybe Word32
     , blockStatsMinTxSize :: Maybe Word32
     , blockStatsOuts :: Maybe Word32
@@ -97,7 +97,7 @@ data BlockStats = BlockStats
     , blockStatsTotalOut :: Maybe Int64
     , blockStatsTotalSize :: Maybe Word32
     , blockStatsTotalWeight :: Maybe Word32
-    , blockStatsTotalFee :: Maybe Word32
+    , blockStatsTotalFee :: Maybe Word64
     , blockStatsCount :: Maybe Word32
     , blockStatsUtxoIncrease :: Maybe Int
     , blockStatsUtxoSizeIncrease :: Maybe Int


### PR DESCRIPTION
This basically allows downstream users to specify only the statistics they
need from the `getblockstats` response, previous to this the caller got every
field but the RPC command allows selective stat selection and I feel the
client we expose should too.

Another fix packed in this PR is that when querying stats for blocks with big
fees I observed errors like:

```
DecodingError "Error in $.totalfee: parsing Word32 failed, value is either floating or will cause over or underflow 8.521634113e9"
```

Same for `maxfee`, so we need to use wider types for these fields. It is worth
mentioning that in bitcoin-core these are `int64_t` however I'm not sure we
blindly want to match these types since it would be very weird to observe
negative values on these fields.