### PR TITLE
Block difficulty to use double instead of arbitrary precision

### DIFF
--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -149,7 +149,7 @@ data BlockHeader = BlockHeader
     , blockHeaderTime :: UTCTime
     , blockHeaderMedianTime :: UTCTime
     , blockHeaderNonce :: Word64
-    , blockHeaderDifficulty :: Scientific
+    , blockHeaderDifficulty :: Double
     , blockHeaderTxCount :: Int
     , blockHeaderPrevHash :: Maybe BlockHash
     , blockHeaderNextHash :: Maybe BlockHash


### PR DESCRIPTION
Back in #14 I added the difficulty value to the block header response as a `Scientific` number for arbitrary precision, however, I now think this was an oversight and instead should have been a `double`. This is because in bitcoin-core the block difficulty value corresponds to a `double` therefore it doesn't make sense for us to provide this number as being of arbitrary precision when in reality it isn't.