### PR TITLE
Relax servant-client constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,17 @@ cabal build all && cabal test all
 ```
 
 Please use `ormolu` or `fourmolu` (with the default configuration) for code formatting.
+
+Known issues
+----
+
+- A bug in `servant-client` regarding the mishandling of empty query string
+  parameters causes bad requests to be sent to bitcoin's RPC server using this
+  library; the issue has since been fixed upstream in servant by
+  https://github.com/haskell-servant/servant/pull/1589, however the fix is
+  only released on `servant-client-0.20` or newer, if you need a build plan
+  where only `servant-client-0.19` is available (e.g. stackage LTS <21.22)
+  make sure to include that fix, or pin
+  `58aa0d1c0c19f7b1c26ffc52bfd65c70934704c9` which is the latest release on
+  `servant-0.19.*` series that's known to work reliably. Most likely if using
+  GHC 9.6 or greater there's no need to worry about this.

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -26,7 +26,7 @@ common core
         , http-client >=0.6 && <0.8
         , process ^>=1.6
         , servant >=0.19 && <0.21
-        , servant-client >=0.19.1 && <0.21
+        , servant-client >=0.19 && <0.21
         , temporary ^>=1.3
         , text >=1.2 && <2.1
 

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -44,7 +44,7 @@ library
         , mtl >=2.2 && <2.4
         , scientific ^>=0.3
         , servant >=0.19 && <0.21
-        , servant-client >=0.19.1 && <0.21
+        , servant-client >=0.19 && <0.21
         , servant-jsonrpc-client >=1.0 && <1.2
         , text >=1.2 && <2.1
         , time >=1.8 && <1.14


### PR DESCRIPTION
It seems that back in #15 I set too tight the constraints on servant-client, downstream consumers are not able to find a build plan when using the stackage snapshot LTS 21.22 for the simple reason that `servant-client-0.19.1` does not exist, there's however a version of `servant-0.19.1` that when pinning `servant-client` to the released sources of that version will make everything work just fine, but only if we have `>=0.19` and not `>=0.19.1` (because servant-client itself doesn't have that version).

Downstream users on stackage LTS 21.22 need to pin servant-client at `58aa0d1c0c19f7b1c26ffc52bfd65c70934704c9`, strictly speaking we do not need the pin here because `servant-client-0.20` will be used and that works just fine, it's only if the build plan selects `servant-client-0.19` that we need this.

I've put a note about this in the README.