### PR TITLE
Fix FromJSON instance for `GetBlockV2Response`

### DIFF
--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -411,8 +411,8 @@ instance FromJSON GetBlockV2Response where
             <*> o .: "confirmations"
             <*> o .: "height"
             <*> o .: "version"
-            <*> o .: "previousblockhash"
-            <*> o .: "nextblockhash"
+            <*> o .:? "previousblockhash"
+            <*> o .:? "nextblockhash"
             <*> (o .: "merkleroot" >>= parseFromHex)
             <*> (utcTime <$> o .: "time")
             <*> (unHexEncoded <$> o .: "bits")


### PR DESCRIPTION
For blocks at the extremes of the chain, the `getblock` response won't have a previous/next block hash key, we already expect maybe values for these in the type but the JSON instance was not in sync with that.