### PR TITLE
Stackage LTS-22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist-newstyle/
 *.out
 /cabal.project.local
 TAGS
+.stack-work

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -15,20 +15,7 @@ common core
     default-language: Haskell2010
     ghc-options:      -Wall -fno-warn-unused-do-bind
     build-depends:
-          async >=2.0 && <2.3
-        , base >=4.12 && <4.18
-        , base64 ^>=0.4
-        , bitcoind-rpc ^>=0.3
-        , bytestring >=0.10 && <0.12
-        , cereal ^>=0.5
-        , directory ^>=1.3
-        , haskoin-core >=0.15 && <0.22
-        , http-client >=0.6 && <0.8
-        , process ^>=1.6
-        , servant >=0.19 && <0.21
-        , servant-client >=0.19 && <0.21
-        , temporary ^>=1.3
-        , text >=1.2 && <2.1
+        , base >=4.12 && <4.19
 
 library
     import:         core
@@ -38,12 +25,24 @@ library
         Bitcoin.Core.Regtest
 
     other-modules:
+        Bitcoin.Core.Regtest.Crypto
         Bitcoin.Core.Regtest.Generator
         Bitcoin.Core.Regtest.Framework
 
     build-depends:
-          attoparsec >=0.13 && <0.15
+          async >=2.0 && <2.3
+        , attoparsec >=0.13 && <0.15
+        , bitcoind-rpc ^>=0.3
+        , bytestring >=0.10 && <0.12
+        , cereal ^>=0.5
         , containers >=0.5 && <0.7
+        , directory ^>=1.3
+        , haskoin-core >=1.0.0 && <1.2
+        , http-client >=0.6 && <0.8
+        , process ^>=1.6
+        , servant >=0.19 && <0.21
+        , temporary ^>=1.3
+        , text >=1.2 && <2.1
         , transformers >=0.5 && <0.7
 
 executable bitcoind-rpc-explorer
@@ -54,6 +53,8 @@ executable bitcoind-rpc-explorer
           bitcoind-regtest
         , bytestring >=0.10 && <0.12
         , optparse-applicative >=0.14 && <0.20
+        , process ^>=1.6
+        , servant >=0.19 && <0.21
 
 
 executable bitcoind-regtest-autominer
@@ -62,8 +63,13 @@ executable bitcoind-regtest-autominer
     hs-source-dirs: autominer/
     ghc-options: -threaded -O2
     build-depends:
-          bitcoind-regtest
+          async >=2.0 && <2.3
+        , bitcoind-regtest
+        , bitcoind-rpc ^>=0.3
+        , haskoin-core >=1.0.0 && <1.2
+        , http-client >=0.6 && <0.8
         , optparse-applicative >=0.14 && <0.20
+        , text >=1.2 && <2.1
 
 test-suite bitcoind-rpc-tests
     import:         core

--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -85,7 +85,16 @@ test-suite bitcoind-rpc-tests
         Bitcoin.Core.Test.Wallet
 
     build-depends:
+          async >=2.0 && <2.3
+        , base64 ^>=0.4
         , bitcoind-regtest
+        , bitcoind-rpc ^>=0.3
+        , cereal ^>=0.5
         , containers ^>=0.6
+        , directory ^>=1.3
+        , haskoin-core >=1.0.0 && <1.2
+        , http-client >=0.6 && <0.8
         , tasty >=1.2 && <1.5
         , tasty-hunit ^>=0.10
+        , temporary ^>=1.3
+        , text >=1.2 && <2.1

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Crypto.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Crypto.hs
@@ -1,0 +1,14 @@
+module Bitcoin.Core.Regtest.Crypto (
+    globalContext,
+) where
+
+import Haskoin.Crypto (Ctx, createContext)
+import System.IO.Unsafe (unsafePerformIO)
+
+{- | The global context is created once and never modified again, it is to be passed into cryptographic
+functions and contains a number of large data structures that are generated at runtime. Impure functions like
+`destroyContext` or `randomizeContext` must not be used against this global value
+-}
+{-# NOINLINE globalContext #-}
+globalContext :: Ctx
+globalContext = unsafePerformIO createContext

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -9,7 +9,7 @@ module Bitcoin.Core.Test.Misc (
 import Bitcoin.Core.RPC
 import Bitcoin.Core.Regtest (NodeHandle)
 import qualified Bitcoin.Core.Regtest as R
-import Bitcoin.Core.Test.Utils (bitcoindTest, testRpc)
+import Bitcoin.Core.Test.Utils (bitcoindTest, globalContext, testRpc)
 import Control.Monad (replicateM)
 import Data.Text (Text)
 import Data.Word (Word64)

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Misc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
@@ -5,27 +6,26 @@ module Bitcoin.Core.Test.Misc (
     miscRPC,
 ) where
 
+import Bitcoin.Core.RPC
+import Bitcoin.Core.Regtest (NodeHandle)
+import qualified Bitcoin.Core.Regtest as R
+import Bitcoin.Core.Test.Utils (bitcoindTest, testRpc)
 import Control.Monad (replicateM)
 import Data.Text (Text)
 import Data.Word (Word64)
 import Haskoin.Address (Address (..), addrToText, pubKeyAddr)
 import Haskoin.Block (Block (..), BlockHash)
-import Haskoin.Constants (btcTest)
-import Haskoin.Crypto (SecKey)
-import Haskoin.Keys (
-    PubKeyI,
-    derivePubKeyI,
+import Haskoin.Crypto (
+    PublicKey,
+    SecKey,
+    derivePublicKey,
     secKey,
     wrapSecKey,
  )
+import Haskoin.Network.Constants (btcTest)
 import Haskoin.Transaction (OutPoint (..), Tx (..), TxHash, txHash)
 import Network.HTTP.Client (Manager)
 import Test.Tasty (TestTree, testGroup)
-
-import Bitcoin.Core.RPC
-import Bitcoin.Core.Regtest (NodeHandle)
-import qualified Bitcoin.Core.Regtest as R
-import Bitcoin.Core.Test.Utils (bitcoindTest, testRpc)
 
 miscRPC :: Manager -> NodeHandle -> TestTree
 miscRPC mgr h =
@@ -70,11 +70,11 @@ testGenerate = generateToAddress 120 addrText Nothing
 key :: SecKey
 Just key = secKey "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
-pk :: PubKeyI
-pk = derivePubKeyI $ wrapSecKey True key
+pk :: PublicKey
+pk = derivePublicKey globalContext $ wrapSecKey True key
 
 addr :: Address
-addr = pubKeyAddr pk
+addr = pubKeyAddr globalContext pk
 
 addrText :: Text
 Just addrText = addrToText btcTest addr
@@ -94,8 +94,9 @@ testBlockStats :: BitcoindClient BlockStats
 testBlockStats = getBestBlockHash >>= \h -> getBlockStats h Nothing
 
 testGetTransaction :: BitcoindClient Tx
-testGetTransaction =
-    getBestBlockHash >>= getBlock' >>= (`getRawTransaction` Nothing) . txHash . head . blockTxns
+testGetTransaction = do
+    block <- getBlock' =<< getBestBlockHash
+    getRawTransaction (txHash $ head block.txs) Nothing
   where
     getBlock' h = getBlockBlock <$> getBlock h (Just 0)
 

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
@@ -11,7 +11,6 @@ import Bitcoin.Core.RPC (
     ListUnspentOptions (ListUnspentOptions),
     PsbtInput,
     PsbtOutputs (PsbtOutputs),
-    globalContext,
     withWallet,
  )
 import qualified Bitcoin.Core.RPC as RPC
@@ -19,6 +18,7 @@ import Bitcoin.Core.Regtest (NodeHandle, Version, nodeVersion, v21_0)
 import Bitcoin.Core.Test.Utils (
     bitcoindTest,
     generate,
+    globalContext,
     initWallet,
     testRpc,
     toInput,

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
@@ -5,20 +5,13 @@ module Bitcoin.Core.Test.PSBT (
     psbtRPC,
 ) where
 
-import Control.Monad (replicateM_, when)
-import Data.ByteString.Base64 (encodeBase64)
-import Data.Functor (void)
-import Data.Maybe (mapMaybe)
-import qualified Data.Serialize as S
-import Network.HTTP.Client (Manager)
-import Test.Tasty (TestTree, testGroup)
-
 import Bitcoin.Core.RPC (
     BitcoindClient,
     Descriptor (Descriptor),
     ListUnspentOptions (ListUnspentOptions),
     PsbtInput,
     PsbtOutputs (PsbtOutputs),
+    globalContext,
     withWallet,
  )
 import qualified Bitcoin.Core.RPC as RPC
@@ -30,6 +23,14 @@ import Bitcoin.Core.Test.Utils (
     testRpc,
     toInput,
  )
+import Control.Monad (replicateM_, when)
+import Data.ByteString.Base64 (encodeBase64)
+import Data.Functor (void)
+import Data.Maybe (mapMaybe)
+import qualified Data.Serialize as S
+import Haskoin.Transaction (putPSBT)
+import Network.HTTP.Client (Manager)
+import Test.Tasty (TestTree, testGroup)
 
 psbtRPC :: Manager -> NodeHandle -> TestTree
 psbtRPC mgr h =
@@ -106,4 +107,4 @@ testPSBT v = when (v >= v21_0) $ do
   where
     wallet = "testPSBT"
 
-    toBase64 = encodeBase64 . S.encode
+    toBase64 = encodeBase64 . S.runPut . putPSBT globalContext

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -24,6 +24,7 @@ library
         Bitcoin.Core.RPC.Blockchain
         Bitcoin.Core.RPC.Generating
         Bitcoin.Core.RPC.Control
+        Bitcoin.Core.RPC.Crypto
         Bitcoin.Core.RPC.Network
         Bitcoin.Core.RPC.Transactions
         Bitcoin.Core.RPC.Wallet
@@ -32,13 +33,13 @@ library
 
     build-depends:
           aeson >=2.0 && <2.2
-        , base >=4.12 && <4.18
+        , base >=4.12 && <4.19
         , base64 ^>=0.4
         , bytestring >=0.10 && <0.12
         , bitcoin-compact-filters ^>=0.1
         , cereal ^>=0.5
         , containers ^>=0.6
-        , haskoin-core >=0.17.1 && <0.22
+        , haskoin-core >=1.0.0 && < 1.2
         , http-client >=0.6 && <0.8
         , http-types ^>=0.12
         , mtl >=2.2 && <2.4
@@ -49,4 +50,3 @@ library
         , text >=1.2 && <2.1
         , time >=1.8 && <1.14
         , transformers >=0.5 && <0.7
-

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Blockchain.hs
@@ -61,8 +61,8 @@ import Data.Text (Text)
 import Data.Time (NominalDiffTime, UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word16, Word32, Word64)
-import qualified Haskoin as H
 import Haskoin.Block (Block (..), BlockHash, BlockHeight, hexToBlockHash)
+import qualified Haskoin.Block as H hiding (GetBlocks (..), GetHeaders (..))
 import Haskoin.Crypto (Hash256)
 import Haskoin.Transaction (Tx, TxHash)
 import Servant.API ((:<|>) (..))
@@ -502,12 +502,12 @@ getBlockBlock = getBlockResponse id responseToBlock
     responseToBlock response =
         Block
             ( H.BlockHeader
-                { H.blockVersion = getBlockV2Version response
-                , H.merkleRoot = getBlockV2MerkleRoot response
-                , H.blockBits = getBlockV2Bits response
-                , H.bhNonce = getBlockV2Nonce response
-                , H.blockTimestamp = round . utcTimeToPOSIXSeconds $ getBlockV2Time response
-                , H.prevBlock =
+                { H.version = getBlockV2Version response
+                , H.merkle = getBlockV2MerkleRoot response
+                , H.bits = getBlockV2Bits response
+                , H.nonce = getBlockV2Nonce response
+                , H.timestamp = round . utcTimeToPOSIXSeconds $ getBlockV2Time response
+                , H.prev =
                     fromMaybe (error "no previous block hash on genesis") $
                         getBlockV2PreviousBlockHash response
                 }

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Crypto.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Crypto.hs
@@ -1,0 +1,14 @@
+module Bitcoin.Core.RPC.Crypto (
+    globalContext,
+) where
+
+import Haskoin.Crypto (Ctx, createContext)
+import System.IO.Unsafe (unsafePerformIO)
+
+{- | The global context is created once and never modified again, it is to be passed into cryptographic
+functions and contains a number of large data structures that are generated at runtime. Impure functions like
+`destroyContext` or `randomizeContext` must not be used against this global value
+-}
+{-# NOINLINE globalContext #-}
+globalContext :: Ctx
+globalContext = unsafePerformIO createContext

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Transactions.hs
@@ -60,7 +60,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Word (Word32, Word64)
 import Haskoin.Block (BlockHash, BlockHeight)
-import Haskoin.Transaction (PartiallySignedTransaction, Tx, TxHash)
+import Haskoin.Transaction (PSBT, Tx, TxHash)
 import Haskoin.Util (encodeHex)
 import Servant.API ((:<|>) (..))
 import Servant.Bitcoind (
@@ -96,7 +96,7 @@ type RawTxRpc =
                   I PsbtOutputs ->
                   O Int ->
                   O Bool ->
-                  C (Base64Encoded PartiallySignedTransaction)
+                  C (Base64Encoded PSBT)
                 )
         :<|> BitcoindEndpoint
                 "finalizepsbt"
@@ -104,8 +104,8 @@ type RawTxRpc =
                   O Bool ->
                   C FinalizePsbtResponse
                 )
-        :<|> BitcoindEndpoint "joinpsbts" (I [Text] -> C (Base64Encoded PartiallySignedTransaction))
-        :<|> BitcoindEndpoint "utxoupdatepsbt" (I Text -> I [Descriptor] -> C (Base64Encoded PartiallySignedTransaction))
+        :<|> BitcoindEndpoint "joinpsbts" (I [Text] -> C (Base64Encoded PSBT))
+        :<|> BitcoindEndpoint "utxoupdatepsbt" (I Text -> I [Descriptor] -> C (Base64Encoded PSBT))
         :<|> BitcoindEndpoint "estimatesmartfee" (I Int -> O FeeEstimationMode -> C EstimateSmartFeeResponse)
 
 sendRawTransaction
@@ -272,7 +272,7 @@ createPsbt ::
     Maybe Int ->
     -- | Marks this transaction as BIP125 replaceable.
     Maybe Bool ->
-    BitcoindClient PartiallySignedTransaction
+    BitcoindClient PSBT
 createPsbt inputs outputs locktime = fmap unBase64Encoded . createPsbt_ inputs outputs locktime
 
 createPsbt_ ::
@@ -280,11 +280,11 @@ createPsbt_ ::
     PsbtOutputs ->
     Maybe Int ->
     Maybe Bool ->
-    BitcoindClient (Base64Encoded PartiallySignedTransaction)
+    BitcoindClient (Base64Encoded PSBT)
 
 -- | @since 0.3.0.0
 data FinalizePsbtResponse = FinalizePsbtResponse
-    { finalizedPsbt :: Maybe PartiallySignedTransaction
+    { finalizedPsbt :: Maybe PSBT
     -- ^ The base64-encoded partially signed transaction if not extracted
     , finalizedTx :: Maybe Tx
     -- ^ The hex-encoded network transaction if extracted
@@ -325,12 +325,12 @@ finalizePsbt ::
 joinPsbts ::
     -- | A base64 string of a PSBT
     [Text] ->
-    BitcoindClient PartiallySignedTransaction
+    BitcoindClient PSBT
 joinPsbts = fmap unBase64Encoded . joinPsbts_
 
 joinPsbts_ ::
     [Text] ->
-    BitcoindClient (Base64Encoded PartiallySignedTransaction)
+    BitcoindClient (Base64Encoded PSBT)
 
 -- | @since 0.3.0.0
 data Descriptor
@@ -356,13 +356,13 @@ utxoUpdatePsbt ::
     -- | A base64 string of a PSBT
     Text ->
     [Descriptor] ->
-    BitcoindClient PartiallySignedTransaction
+    BitcoindClient PSBT
 utxoUpdatePsbt psbt = fmap unBase64Encoded . utxoUpdatePsbt_ psbt
 
 utxoUpdatePsbt_ ::
     Text ->
     [Descriptor] ->
-    BitcoindClient (Base64Encoded PartiallySignedTransaction)
+    BitcoindClient (Base64Encoded PSBT)
 
 -- | @since 0.3.0.0
 data FeeEstimationMode

--- a/bitcoind-rpc/src/Data/Aeson/Utils.hs
+++ b/bitcoind-rpc/src/Data/Aeson/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -19,22 +20,15 @@ module Data.Aeson.Utils (
     Base64Encoded (..),
 ) where
 
-import Control.Monad ((<=<), (>=>))
-import Data.Aeson (
-    FromJSON (..),
-    Key,
-    ToJSON (..),
-    Value,
-    object,
-    withText,
-    (.=),
- )
+import Bitcoin.Core.RPC.Crypto (globalContext)
+import Control.Monad ((<=<))
+import Data.Aeson (FromJSON (..), Key, ToJSON (..), Value (..), object, withText, (.=))
 import Data.Aeson.Types (Pair)
 import Data.Bifunctor (first)
 import Data.ByteString.Base64 (decodeBase64, encodeBase64)
 import Data.Maybe (catMaybes)
 import Data.Scientific (Scientific)
-import Data.Serialize (Serialize, decode)
+import Data.Serialize (Serialize)
 import qualified Data.Serialize as S
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -42,7 +36,9 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Word (Word64)
-import Haskoin.Util (decodeHex, encodeHex)
+import Haskoin.Crypto (PublicKey)
+import Haskoin.Transaction (PSBT, getPSBT, putPSBT)
+import Haskoin.Util (decodeHex, encodeHex, marshal, unmarshal)
 
 partialObject :: [Maybe Pair] -> Value
 partialObject = object . catMaybes
@@ -71,7 +67,7 @@ rangeToJSON (n, _) = toJSON n
 
 -- | Read a serializable from a hex string
 decodeFromHex :: (Serialize a) => Text -> Either String a
-decodeFromHex = maybe (Left "Invalid hex") Right . decodeHex >=> decode
+decodeFromHex = S.decode <=< maybe (Left "Invalid hex") Right . decodeHex
 
 newtype HexEncoded a = HexEncoded {unHexEncoded :: a} deriving (Eq, Show)
 
@@ -80,6 +76,17 @@ instance (Serialize a) => FromJSON (HexEncoded a) where
 
 instance (Serialize a) => ToJSON (HexEncoded a) where
     toJSON = toJSON . encodeHex . S.encode . unHexEncoded
+
+instance {-# OVERLAPPING #-} FromJSON (HexEncoded PublicKey) where
+    parseJSON =
+        withText "HexEncoded PublicKey" $
+            either fail (pure . HexEncoded)
+                . unmarshal globalContext
+                <=< maybe (fail "Invalid hex") pure
+                    . decodeHex
+
+instance {-# OVERLAPPING #-} ToJSON (HexEncoded PublicKey) where
+    toJSON = toJSON . encodeHex . marshal globalContext . unHexEncoded
 
 newtype Base64Encoded a = Base64Encoded {unBase64Encoded :: a} deriving (Eq, Show)
 
@@ -92,3 +99,12 @@ instance (Serialize a) => FromJSON (Base64Encoded a) where
 
 instance (Serialize a) => ToJSON (Base64Encoded a) where
     toJSON = toJSON . encodeBase64 . S.encode . unBase64Encoded
+
+instance {-# OVERLAPPING #-} ToJSON (Base64Encoded PSBT) where
+    toJSON = toJSON . encodeBase64 . S.runPut . putPSBT globalContext . unBase64Encoded
+
+instance {-# OVERLAPPING #-} FromJSON (Base64Encoded PSBT) where
+    parseJSON =
+        withText "PSBT" $
+            either fail (pure . Base64Encoded) . S.runGet (getPSBT globalContext)
+                <=< either (fail . Text.unpack) pure . decodeBase64 . encodeUtf8


### PR DESCRIPTION
# Description

This PR makes necessary updates to the bitcoind-rpc and bitcoind-regtest libraries for use with GHC 9.6 and Haskoin-core >=1.0, both in stackage LTS 22

This PR is similar to, and is necessarily compatible with https://github.com/bitnomial/bitcoin-scripting/pull/11

Apart from some name changes, the most significant change is that functions that relied on the secp25k1 context now pass that in explicitly. Consequently, some functions for serializing/encoding have changed, and many functions have had a `Ctx` parameter added.

Also, in haskoin-core, accessor functions have been removed for record types, they're preferring to use `OverloadedRecordDot` syntax, so in some modules that has been added here.

The dependencies were also reviewed, removing unused deps and moving common deps that are only needed in some components to the relevant components. Otherwise, the changes were kept as local as possible.

# Testing

The tests pass as expected