### PR TITLE
Updates library to support some more recent versions of bitcoind

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,12 @@ This package provides some tooling for testing a bitcoin-core integration.  Feat
 Supported bitcoin-core versions
 ----
 
-Full support only for `v22.0`.
+Full support only for `v27.0`.
 
 Limited support for:
 
-* `v0.19.1`
-* `v0.20.0`
-* `v0.20.1`
-* `v0.21.0`
-* `v0.21.1`
-* `v0.21.0` 
-* `v0.21.1`
+* `v25.2`
+* `v26.1`
 
 Test suite
 ----

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest.hs
@@ -33,13 +33,11 @@ module Bitcoin.Core.Regtest (
     textAddrs,
 
     -- * Versions
-    v19_1,
-    v20_0,
-    v20_1,
-    v21_0,
-    v21_1,
-    v22_0,
-    v23_0,
+    v23_2,
+    v24_2,
+    v25_2,
+    v26_1,
+    v27_0,
 ) where
 
 import Bitcoin.Core.Regtest.Framework

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -35,13 +35,9 @@ module Bitcoin.Core.Regtest.Framework (
     textAddrs,
 
     -- * Versions
-    v19_1,
-    v20_0,
-    v20_1,
-    v21_0,
-    v21_1,
-    v22_0,
-    v23_0,
+    v25_2,
+    v26_1,
+    v27_0,
 ) where
 
 import Bitcoin.Core.Regtest.Crypto (globalContext)
@@ -349,11 +345,7 @@ textAddrs = addrToText' <$> addrs
 textAddr0, textAddr1, textAddr2 :: Text
 textAddr0 : textAddr1 : textAddr2 : _ = textAddrs
 
-v19_1, v20_0, v20_1, v21_0, v21_1, v22_0, v23_0 :: Version
-v19_1 = (0, 19, 1)
-v20_0 = (0, 20, 0)
-v20_1 = (0, 20, 1)
-v21_0 = (0, 21, 0)
-v21_1 = (0, 21, 1)
-v22_0 = (22, 0, 0)
-v23_0 = (23, 0, 0)
+v25_2, v26_1, v27_0 :: Version
+v25_2 = (25, 2, 0)
+v26_1 = (26, 1, 0)
+v27_0 = (27, 0, 0)

--- a/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
+++ b/bitcoind-regtest/src/Bitcoin/Core/Regtest/Framework.hs
@@ -120,8 +120,6 @@ data NodeHandle = NodeHandle
     { nodeP2pPort :: Int
     , nodeRpcPort :: Int
     , nodeAuth :: BasicAuthData
-    , nodeRawTx :: FilePath
-    , nodeRawBlock :: FilePath
     , nodeVersion :: Version
     }
 
@@ -165,8 +163,6 @@ withBitcoind basePort dataDir k = do
                         basePort
                         (getRpcPort basePort)
                         auth
-                        (rawTxSocket dd)
-                        (rawBlockSocket dd)
                         v
             mgr <- newManager defaultManagerSettings
             waitForRPC mgr nodeHandle
@@ -238,8 +234,6 @@ bitcoind ddir basePort output =
         , "-datadir=" <> ddir
         , "-port=" <> show (getPeerPort basePort)
         , "-rpcport=" <> show (getRpcPort basePort)
-        , "-zmqpubrawblock=" <> rawBlockSocket ddir
-        , "-zmqpubrawtx=" <> rawTxSocket ddir
         ]
 
 getPeerPort :: Int -> Int
@@ -247,12 +241,6 @@ getPeerPort = id
 
 getRpcPort :: Int -> Int
 getRpcPort = (+ 1)
-
-rawTxSocket :: FilePath -> String
-rawTxSocket tmp = "ipc://" <> tmp <> "/bitcoind-rpc.tx.raw"
-
-rawBlockSocket :: FilePath -> String
-rawBlockSocket tmp = "ipc://" <> tmp <> "/bitcoind-rpc.block.raw"
 
 oneBitcoin :: Word64
 oneBitcoin = 100_000_000

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Utils.hs
@@ -46,7 +46,7 @@ createWallet walletName =
         Nothing
         mempty
         (Just True)
-        (Just False)
+        Nothing
         Nothing
         Nothing
 

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/Wallet.hs
@@ -66,7 +66,7 @@ testWalletCommands = do
             Nothing
             walletPassword
             (Just True)
-            (Just False) -- legacy wallet
+            Nothing
             Nothing
             Nothing
     liftIO $ RPC.loadWalletName loadWalletR @?= walletName

--- a/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
+++ b/bitcoind-rpc/src/Bitcoin/Core/RPC/Wallet.hs
@@ -552,7 +552,7 @@ data LoadWalletResponse = LoadWalletResponse
     { loadWalletName :: Text
     -- ^ The wallet name if created successfully. If the wallet was created
     -- using a full path, the wallet_name will be the full path.
-    , loadWalletWarning :: Text
+    , loadWalletWarning :: Maybe Text
     -- ^ Warning message if wallet was not loaded cleanly.
     }
     deriving (Eq, Show)
@@ -561,7 +561,7 @@ instance FromJSON LoadWalletResponse where
     parseJSON = withObject "LoadWalletResponse" $ \obj ->
         LoadWalletResponse
             <$> obj .: "name"
-            <*> obj .: "warning"
+            <*> obj .:? "warning"
 
 -- | Creates and loads a new wallet.
 createWallet ::
@@ -2045,11 +2045,13 @@ signRawTx ::
     Maybe Text ->
     BitcoindClient SignRawTxResponse
 
-newtype UnloadWalletResponse = UnloadWalletResponse {unUnloadWalletResponse :: Text}
+newtype UnloadWalletResponse = UnloadWalletResponse {unUnloadWalletResponse :: Maybe Text}
     deriving (Eq, Show)
 
 instance FromJSON UnloadWalletResponse where
-    parseJSON = withObject "UnloadWalletResponse" $ fmap UnloadWalletResponse . (.: "warning")
+    parseJSON =
+        withObject "UnloadWalletResponse" $
+            fmap UnloadWalletResponse . (.:? "warning")
 
 unloadWallet_ ::
     Maybe Text ->
@@ -2069,7 +2071,7 @@ unloadWallet ::
     -- | Save wallet name to persistent settings and load on startup. True to
     -- add wallet to startup list, false to remove, null to leave unchanged.
     Maybe Bool ->
-    BitcoindClient Text
+    BitcoindClient (Maybe Text)
 unloadWallet name = fmap unUnloadWalletResponse . unloadWallet_ name
 
 -- | @since 0.3.0.0

--- a/cabal.project
+++ b/cabal.project
@@ -20,7 +20,3 @@ source-repository-package
   subdir:
     servant-jsonrpc
     servant-jsonrpc-client
-
-constraints:
-  -- haskoin-core-0.21.2 needs
-  base16 < 1

--- a/nix/bitcoind-versions.nix
+++ b/nix/bitcoind-versions.nix
@@ -1,36 +1,14 @@
 {
-  v0-19-1 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-x86_64-linux-gnu.tar.gz";
-    sha256 = "032fz20d0nhc07gcharidmzbz3y871gk4i1lvv7yrh5nkz7pqxpq";
+  v25-2 = builtins.fetchTarball {
+    url = "https://bitcoincore.org/bin/bitcoin-core-25.2/bitcoin-25.2-x86_64-linux-gnu.tar.gz";
+    sha256 = "16a4lpvk19m6bmys4zlyh0q5wx83q7v2whjjdb32x0shgzpzvcmy";
   };
-
-  v0-20-0 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz";
-    sha256 = "02rizar9h2frip8m4lamdvjag18kb0blsnpckdy28mgvcck3z6ab";
+  v26-1 = builtins.fetchTarball {
+    url = "https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-x86_64-linux-gnu.tar.gz";
+    sha256 = "1brxbss4xkhnh5fzp32dgwjwvz0y3y6sn9pa9w48s51p43m7n917";
   };
-
-  v0-20-1 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-x86_64-linux-gnu.tar.gz";
-    sha256 = "0rh4x2gvihgrsz7rb6z4iq6xsm7pmiyrrs03adyadfim6yac786h";
-  };
-
-  v0-21-0 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-0.21.0/bitcoin-0.21.0-x86_64-linux-gnu.tar.gz";
-    sha256 = "1kfx4wbigrgiwx3s7609wp4g371b63r1hvij83h25i1j3dm4wijv";
-  };
-
-  v0-21-1 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-x86_64-linux-gnu.tar.gz";
-    sha256 = "05zn4dizi4kwbqid0vds90dwap6k6zrg8pv8qc7sxv2wg82klv9q";
-  };
-
-  v22-0 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-22.0/bitcoin-22.0-x86_64-linux-gnu.tar.gz";
-    sha256 = "08l18bihda64bka4lhv046kdcjgwwngwws6v08lnrkp8j0l2l2rk";
-  };
-
-  v23-0 = builtins.fetchTarball {
-    url = "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-x86_64-linux-gnu.tar.gz";
-    sha256 = "01hf9h88sw06ppsx2pxshw6a4bd1j1yg4kgjrxdcr54gmwk891kn";
+  v27-0 = builtins.fetchTarball {
+    url = "https://bitcoincore.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-linux-gnu.tar.gz";
+    sha256 = "05i4zrdwr2rnbimf4fmklbm1mrvxg1bnv3yrrx44cp66ba0nd3jg";
   };
 }

--- a/nix/multi-version-test.nix
+++ b/nix/multi-version-test.nix
@@ -1,27 +1,29 @@
-let pkgs = import <nixpkgs> {};
-    versions = import ./bitcoind-versions.nix;
+let
+  pkgs = import <nixpkgs> { };
+  versions = import ./bitcoind-versions.nix;
 
-    test = bitcoinInstance: pkgs.writeScript "cabal-test"
-      ''
+  test = bitcoinInstance: pkgs.writeScript "cabal-test"
+    ''
       export PATH=${bitcoinInstance}/bin:$PATH
       bitcoind -version | head -n 1
       cabal test all
-      '';
+    '';
 
-    testVersions = builtins.attrValues versions;
+  testVersions = builtins.attrValues versions;
 
-    testInstance = v: toString (test v);
+  testInstance = v: toString (test v);
 
-    testMany = pkgs.writeScript "test-many"
-      ''
+  testMany = pkgs.writeScript "test-many"
+    ''
       set -e
 
       separator () {
-        echo -e "\n\n~~~~~~~~~~\n\n"
+        echo "\n\n~~~~~~~~~~\n\n"
       }
 
       ${builtins.concatStringsSep "; separator; " (map testInstance testVersions)}
 
-      '';
+    '';
 
-in testMany
+in
+testMany


### PR DESCRIPTION
The main recent change is the deprecation of the legacy wallet in version 26.  This change updates the tests to test against the descriptor wallet and drops tests for RPC calls that only work for the legacy wallet.  There are also some minor implementation changes:

- "warning" field is optional on some wallet-related calls, we changed the type to `Maybe`
- `haskoin-core` does not support `h` markings for hard derivation path segments, so we shim that
- Recent versions of Bitcoin Core do not allow binding the ZMQ endpoints on a unix domain socket, so we just drop these bindings from the regtest framework.  If there is interest, we can come up with ports and add them back.

I also changed the supported version set to only go back to 23.