### PR TITLE
Update to build with GHC 9.8, and new servant-jsonrpc

### DIFF
--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               bitcoind-regtest
-version:            0.4.0.0
+version:            0.4.1.0
 synopsis:           A library for working with bitcoin-core regtest networks
 homepage:           https://github.com/bitnomial/bitcoind-rpc
 license:            BSD-3-Clause
@@ -15,7 +15,7 @@ common core
     default-language: Haskell2010
     ghc-options:      -Wall -fno-warn-unused-do-bind
     build-depends:
-        , base >=4.12 && <4.19
+        , base >=4.12 && <4.22
 
 library
     import:         core
@@ -33,16 +33,16 @@ library
           async >=2.0 && <2.3
         , attoparsec >=0.13 && <0.15
         , bitcoind-rpc ^>=0.3
-        , bytestring >=0.10 && <0.12
+        , bytestring >=0.10 && <0.13
         , cereal ^>=0.5
-        , containers >=0.5 && <0.7
+        , containers >=0.5 && <0.8
         , directory ^>=1.3
         , haskoin-core >=1.0.0 && <1.2
         , http-client >=0.6 && <0.8
         , process ^>=1.6
         , servant >=0.19 && <0.21
         , temporary ^>=1.3
-        , text >=1.2 && <2.1
+        , text >=1.2 && <2.2
         , transformers >=0.5 && <0.7
 
 executable bitcoind-rpc-explorer
@@ -51,7 +51,7 @@ executable bitcoind-rpc-explorer
     hs-source-dirs: rpc-explorer/
     build-depends:
           bitcoind-regtest
-        , bytestring >=0.10 && <0.12
+        , bytestring >=0.10 && <0.13
         , optparse-applicative >=0.14 && <0.20
         , process ^>=1.6
         , servant >=0.19 && <0.21
@@ -69,7 +69,7 @@ executable bitcoind-regtest-autominer
         , haskoin-core >=1.0.0 && <1.2
         , http-client >=0.6 && <0.8
         , optparse-applicative >=0.14 && <0.20
-        , text >=1.2 && <2.1
+        , text >=1.2 && <2.2
 
 test-suite bitcoind-rpc-tests
     import:         core
@@ -86,15 +86,15 @@ test-suite bitcoind-rpc-tests
 
     build-depends:
           async >=2.0 && <2.3
-        , base64 ^>=0.4
+        , base64 ^>=1.0
         , bitcoind-regtest
         , bitcoind-rpc ^>=0.3
         , cereal ^>=0.5
-        , containers ^>=0.6
+        , containers >=0.6 && <0.8
         , directory ^>=1.3
         , haskoin-core >=1.0.0 && <1.2
         , http-client >=0.6 && <0.8
-        , tasty >=1.2 && <1.5
+        , tasty >=1.2 && <1.6
         , tasty-hunit ^>=0.10
         , temporary ^>=1.3
-        , text >=1.2 && <2.1
+        , text >=1.2 && <2.2

--- a/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
+++ b/bitcoind-regtest/test/Bitcoin/Core/Test/PSBT.hs
@@ -24,7 +24,8 @@ import Bitcoin.Core.Test.Utils (
     toInput,
  )
 import Control.Monad (replicateM_)
-import Data.ByteString.Base64 (encodeBase64)
+import qualified Data.Base64.Types as B64
+import qualified Data.ByteString.Base64 as B64
 import Data.Functor (void)
 import Data.Maybe (mapMaybe)
 import qualified Data.Serialize as S
@@ -105,4 +106,4 @@ testPSBT = do
   where
     wallet = "testPSBT"
 
-    toBase64 = encodeBase64 . S.runPut . putPSBT globalContext
+    toBase64 = B64.extractBase64 . B64.encodeBase64 . S.runPut . putPSBT globalContext

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               bitcoind-rpc
-version:            0.3.0.0
+version:            0.3.1.0
 synopsis:           A streamlined interface to bitcoin core using Haskoin types and Servant
 homepage:           https://github.com/bitnomial/bitcoind-rpc
 license:            BSD-3-Clause
@@ -32,13 +32,13 @@ library
         Servant.Bitcoind
 
     build-depends:
-          aeson >=2.0 && <2.2
-        , base >=4.12 && <4.19
-        , base64 ^>=0.4
-        , bytestring >=0.10 && <0.12
+          aeson >=2.0 && <2.3
+        , base >=4.12 && <4.22
+        , base64 ^>=1.0
+        , bytestring >=0.10 && <0.13
         , bitcoin-compact-filters ^>=0.1
         , cereal ^>=0.5
-        , containers ^>=0.6
+        , containers >=0.6 && <0.8
         , haskoin-core >=1.0.0 && < 1.2
         , http-client >=0.6 && <0.8
         , http-types ^>=0.12
@@ -46,7 +46,7 @@ library
         , scientific ^>=0.3
         , servant >=0.19 && <0.21
         , servant-client >=0.19 && <0.21
-        , servant-jsonrpc-client >=1.0 && <1.2
-        , text >=1.2 && <2.1
-        , time >=1.8 && <1.14
+        , servant-jsonrpc-client >=1.2 && <1.3
+        , text >=1.2 && <2.2
+        , time >=1.8 && <1.15
         , transformers >=0.5 && <0.7

--- a/cabal.project
+++ b/cabal.project
@@ -11,12 +11,4 @@ package bitcoind-regtest
 source-repository-package
   type: git
   location: https://github.com/bitnomial/bitcoin-compact-filters
-  tag: 2ae18e7c7b66f1cfe60529645fce0c9b6536e986
-
-source-repository-package
-  type: git
-  location: https://github.com/bitnomial/servant-jsonrpc
-  tag: 938b39d0d0d115f1fceb6b5f5125319d19f82c5f
-  subdir:
-    servant-jsonrpc
-    servant-jsonrpc-client
+  tag: 8dbd961e99fa005005be1ebd97d0982d5ab12e9d


### PR DESCRIPTION
This updates the PR to build with GHC 9.8, against the latest stackage LTS, using the new servant-jsonrpc release

This branch builds and was run against the multi-version test