### PR TITLE
Bump haskoin-core upper bound in cabal files

### DIFF
--- a/bitcoind-regtest/bitcoind-regtest.cabal
+++ b/bitcoind-regtest/bitcoind-regtest.cabal
@@ -37,7 +37,7 @@ library
         , cereal ^>=0.5
         , containers >=0.5 && <0.8
         , directory ^>=1.3
-        , haskoin-core >=1.0.0 && <1.2
+        , haskoin-core >=1.0.0 && <1.3
         , http-client >=0.6 && <0.8
         , process ^>=1.6
         , servant >=0.19 && <0.21
@@ -66,7 +66,7 @@ executable bitcoind-regtest-autominer
           async >=2.0 && <2.3
         , bitcoind-regtest
         , bitcoind-rpc ^>=0.3
-        , haskoin-core >=1.0.0 && <1.2
+        , haskoin-core >=1.0.0 && <1.3
         , http-client >=0.6 && <0.8
         , optparse-applicative >=0.14 && <0.20
         , text >=1.2 && <2.2
@@ -92,7 +92,7 @@ test-suite bitcoind-rpc-tests
         , cereal ^>=0.5
         , containers >=0.6 && <0.8
         , directory ^>=1.3
-        , haskoin-core >=1.0.0 && <1.2
+        , haskoin-core >=1.0.0 && <1.3
         , http-client >=0.6 && <0.8
         , tasty >=1.2 && <1.6
         , tasty-hunit ^>=0.10

--- a/bitcoind-rpc/bitcoind-rpc.cabal
+++ b/bitcoind-rpc/bitcoind-rpc.cabal
@@ -39,7 +39,7 @@ library
         , bitcoin-compact-filters ^>=0.1
         , cereal ^>=0.5
         , containers >=0.6 && <0.8
-        , haskoin-core >=1.0.0 && < 1.2
+        , haskoin-core >=1.0.0 && < 1.3
         , http-client >=0.6 && <0.8
         , http-types ^>=0.12
         , mtl >=2.2 && <2.4


### PR DESCRIPTION
This PR raises the upper bound on haskoin-core to support building with stackage LTS 24